### PR TITLE
Avoid failure if 2 userid-customcertid combos

### DIFF
--- a/element/date/classes/element.php
+++ b/element/date/classes/element.php
@@ -137,9 +137,12 @@ class element extends \mod_customcert\element {
             // Get the customcert this page belongs to.
             $customcert = $DB->get_record('customcert', array('templateid' => $page->templateid), '*', MUST_EXIST);
             // Now we can get the issue for this user.
-            $issue = $DB->get_record('customcert_issues', array('userid' => $user->id, 'customcertid' => $customcert->id),
-                '*', MUST_EXIST);
-
+            $issue = $DB->get_records('customcert_issues', array('userid' => $user->id, 'customcertid' => $customcert->id), 'timecreated DESC', '*', null, 1);
+            if(empty($issue)) {
+                // create new exception which will contain correct table name
+                throw new dml_missing_record_exception('customcert_issues', 'SELECT * FROM {customcert_issues} WHERE userid=:userid AND customcertid=:customcertid ORDER BY timecreated DESC LIMIT 1', array('userid' => $user->id, 'customcertid' => $customcert->id));
+            }
+            
             if ($dateitem == CUSTOMCERT_DATE_ISSUE) {
                 $date = $issue->timecreated;
             } else if ($dateitem == CUSTOMCERT_DATE_COMPLETION) {

--- a/element/date/classes/element.php
+++ b/element/date/classes/element.php
@@ -142,7 +142,7 @@ class element extends \mod_customcert\element {
                 // create new exception which will contain correct table name
                 throw new dml_missing_record_exception('customcert_issues',
                    'SELECT * FROM {customcert_issues} WHERE userid=:userid AND customcertid=:customcertid ORDER BY timecreated DESC LIMIT 1',
-                                                       array('userid' => $user->id, 'customcertid' => $customcert->id));
+                   array('userid' => $user->id, 'customcertid' => $customcert->id));
             }
 
             if ($dateitem == CUSTOMCERT_DATE_ISSUE) {

--- a/element/date/classes/element.php
+++ b/element/date/classes/element.php
@@ -138,9 +138,11 @@ class element extends \mod_customcert\element {
             $customcert = $DB->get_record('customcert', array('templateid' => $page->templateid), '*', MUST_EXIST);
             // Now we can get the issue for this user.
             $issue = $DB->get_records('customcert_issues', array('userid' => $user->id, 'customcertid' => $customcert->id), 'timecreated DESC', '*', null, 1);
-            if(empty($issue)) {
+            if (empty($issue)) {
                 // create new exception which will contain correct table name
-                throw new dml_missing_record_exception('customcert_issues', 'SELECT * FROM {customcert_issues} WHERE userid=:userid AND customcertid=:customcertid ORDER BY timecreated DESC LIMIT 1', array('userid' => $user->id, 'customcertid' => $customcert->id));
+                throw new dml_missing_record_exception('customcert_issues',
+                   'SELECT * FROM {customcert_issues} WHERE userid=:userid AND customcertid=:customcertid ORDER BY timecreated DESC LIMIT 1',
+                                                       array('userid' => $user->id, 'customcertid' => $customcert->id));
             }
             
             if ($dateitem == CUSTOMCERT_DATE_ISSUE) {

--- a/element/date/classes/element.php
+++ b/element/date/classes/element.php
@@ -144,7 +144,7 @@ class element extends \mod_customcert\element {
                    'SELECT * FROM {customcert_issues} WHERE userid=:userid AND customcertid=:customcertid ORDER BY timecreated DESC LIMIT 1',
                                                        array('userid' => $user->id, 'customcertid' => $customcert->id));
             }
-            
+
             if ($dateitem == CUSTOMCERT_DATE_ISSUE) {
                 $date = $issue->timecreated;
             } else if ($dateitem == CUSTOMCERT_DATE_COMPLETION) {


### PR DESCRIPTION
We somehow have two results for
SELECT * FROM m_customcert_issues WHERE userid = 20426 AND customcertid = 35

   	ID	USERID	CUSTOMCERTID	CODE	EMAILED	TIMECREATED
1	8127	20426	35	1cxhyyRCB6	0	1535058946
2	8128	20426	35	Tg7yyHT9rh	0	1535058945

which is causing a fatal error preventing sending any certificate emails afterward.  Not sure if this is from a restore or the user double-clicking submit somewhere.

For those who have a similar issue, this fix gets around the problem by choosing the entry with the max datestamp.