### PR TITLE
Attempt to continue to next certificate/user

### DIFF
--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -140,7 +140,8 @@ class email_certificate_task extends \core\task\scheduled_task {
                         $enroluser->emailed = 0;
                         $issuedusers[] = $enroluser;
                     } catch (Exception $e) {
-                        error_log("Error issuing certificate in courseid={$customcert->courseid} cmid={$cm->id} to userid={$enroluser->id}: " . $e->getMessage());
+                        error_log("Error issuing certificate in courseid={$customcert->courseid} cmid={$cm->id} ".
+                                  "to userid={$enroluser->id}: " . $e->getMessage());
                         continue;
                     }
                 }
@@ -233,7 +234,7 @@ class email_certificate_task extends \core\task\scheduled_task {
                     // Set the field so that it is emailed.
                     $DB->set_field('customcert_issues', 'emailed', 1, array('id' => $user->issueid));
                 }
-            } catch(Exception $e) {
+            } catch (Exception $e) {
                 error_log("Error processing certificate in courseid={$customcert->courseid} cmid={$cm->id}: " . $e->getMessage());
                 continue;
             }


### PR DESCRIPTION
On DB query or other failure, attempt to continue on to the next certificate or user.
In our case, the scheduled task died when:
$issueid = $DB->get_field('customcert_issues', 'id', array('userid' => $enroluser->id, 'customcertid' => $customcert->id));
returned 2 rows, which shouldn't happen, but did anyway.  
This problem blocked sending certificates to other users and sending other certificates.