### PR TITLE
Do not fail if multiple certificate_issues

### DIFF
--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -127,7 +127,7 @@ class email_certificate_task extends \core\task\scheduled_task {
 
                 // Ensure the cert hasn't already been issued, e.g via the UI (view.php) - a race condition.
                 $issueid = $DB->get_field('customcert_issues', 'id',
-                    array('userid' => $enroluser->id, 'customcertid' => $customcert->id));
+                    array('userid' => $enroluser->id, 'customcertid' => $customcert->id), IGNORE_MULTIPLE);
                 if (empty($issueid)) {
                     // Ok, issue them the certificate.
                     $issueid = \mod_customcert\certificate::issue_certificate($customcert->id, $enroluser->id);


### PR DESCRIPTION
Ignore multiple matches for a user-certificate combo in the certificate_issues table
In our case, the scheduled task died when:
$issueid = $DB->get_field('customcert_issues', 'id', array('userid' => $enroluser->id, 'customcertid' => $customcert->id));
returned 2 rows, which shouldn't happen, but did anyway.

This means in rare circumstances (i.e. the race condition) the user may get multiple certificates (e.g. one via the UI, one by email) but that is better than not getting one at all and the whole job dying.