### PR TITLE
Format text element with format_string() to prevent moodle autolink custom text

### DIFF
--- a/element/text/classes/element.php
+++ b/element/text/classes/element.php
@@ -102,6 +102,6 @@ class element extends \mod_customcert\element {
      */
     protected function get_text() : string {
         $context = \mod_customcert\element_helper::get_context($this->get_id());
-        return format_text($this->get_data(), FORMAT_HTML, ['context' => $context]);
+        return format_text($this->get_data(), FORMAT_PLAIN, ['context' => $context]);
     }
 }

--- a/element/text/classes/element.php
+++ b/element/text/classes/element.php
@@ -102,6 +102,6 @@ class element extends \mod_customcert\element {
      */
     protected function get_text() : string {
         $context = \mod_customcert\element_helper::get_context($this->get_id());
-        return format_text($this->get_data(), FORMAT_PLAIN, ['context' => $context]);
+        return format_string($this->get_data(), true, ['context' => $context]);
     }
 }


### PR DESCRIPTION
In cases when text apresent the same word as course name, moodle is linking that and causing font color change and alignment errors.
This change fix that.