### PR TITLE
Add userfullname variable for email subject

### DIFF
--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -160,6 +160,7 @@ class email_certificate_task extends \core\task\scheduled_task {
             // Now, email the people we need to.
             foreach ($issuedusers as $user) {
                 $userfullname = fullname($user);
+                $info->userfullname = $userfullname;
 
                 // Now, get the PDF.
                 $template = new \stdClass();


### PR DESCRIPTION
This PR allow an admin to add userfullname in emails (which can be handy for manager). by using {$a->userfullname} in language pack customization.