### PR TITLE
Feature: Consider Course Completion 

### DIFF
--- a/classes/certificate.php
+++ b/classes/certificate.php
@@ -479,128 +479,125 @@ class certificate {
      * @return bool true if completed, otherwise false
      */
     public static function get_completion_requirements($course) {
-        global $USER, $PAGE, $COMPLETION_CRITERIA_TYPES;
+        global $USER, $PAGE;
         $info = new \completion_info($course);
         $completions = $info->get_completions($USER->id);
         $modinfo = get_fast_modinfo($course);
 
-        // Prepare return object
-        $completion_view = new stdClass();
-        $completion_view->aggregation_method = '';
-        // Markup for prerequisites
-        $completion_view->prerequisites = array();
-        $completion_view->has_prerequisites = false;
-        $completion_view->prerequisites_agg_all = false;
-        $completion_view->prerequisites_agg_any = false;
-        $completion_view->prerequisites_completed = false;
-        // Markup for activities
-        $completion_view->sections = array();
-        $completion_view->has_activities = false;
-        $completion_view->activities_agg_all = false;
-        $completion_view->activities_agg_any = false;
-        $completion_view->activities_completed = false;
-        // Markup for Grade
-        $completion_view->has_grade = new stdClass();
-        $completion_view->has_grade->enabled = false;
-        $completion_view->has_grade->grade = '';
-        $completion_view->has_grade->complete = '';
-        // Markup for Date
-        $completion_view->has_date = false;
-        $completion_view->dates = array();
-        // Markup for Duration
-        $completion_view->has_duration = false;
-        $completion_view->durations = array();
-        // Markup for SelfCompletion
-        $completion_view->has_selfcompletion = false;
-        $completion_view->selfcompletions = array();
-        // Markup for Role
-        $completion_view->has_role = false;
-        $completion_view->roles = array();
-        $completion_view->roles_agg_all = false;
-        $completion_view->roles_agg_any = false;
-        $completion_view->roles_completed = false;
-        // Markup for Unenrolment
-        $completion_view->has_unenrol = false;
-        $completion_view->unenrol = array();
+        // Prepare return object.
+        $completionview = new stdClass();
+        $completionview->aggregation_method = '';
+        // Markup for prerequisites.
+        $completionview->prerequisites = array();
+        $completionview->hasprerequisites = false;
+        $completionview->prerequisitesaggall = false;
+        $completionview->prerequisitesaggany = false;
+        $completionview->prerequisitescompleted = false;
+        // Markup for activities.
+        $completionview->sections = array();
+        $completionview->hasactivities = false;
+        $completionview->activitiesaggall = false;
+        $completionview->activitiesaggany = false;
+        $completionview->activitiescompleted = false;
+        // Markup for Grade.
+        $completionview->hasgrade = new stdClass();
+        $completionview->hasgrade->enabled = false;
+        $completionview->hasgrade->grade = '';
+        $completionview->hasgrade->complete = '';
+        // Markup for Date.
+        $completionview->hasdate = false;
+        $completionview->dates = array();
+        // Markup for Duration.
+        $completionview->hasduration = false;
+        $completionview->durations = array();
+        // Markup for SelfCompletion.
+        $completionview->hasselfcompletion = false;
+        $completionview->selfcompletions = array();
+        // Markup for Role.
+        $completionview->hasrole = false;
+        $completionview->roles = array();
+        $completionview->rolesaggall = false;
+        $completionview->rolesaggany = false;
+        $completionview->rolescompleted = false;
+        // Markup for Unenrolment.
+        $completionview->hasunenrol = false;
+        $completionview->unenrol = array();
 
         // Check for aggregation method
         $overall = $info->get_aggregation_method();
         if ($overall == COMPLETION_AGGREGATION_ALL) {
-            $completion_view->aggregation_method = get_string('criteriarequiredall', 'completion');
+            $completionview->aggregationmethod = get_string('criteriarequiredall', 'completion');
         } else {
-            $completion_view->aggregation_method = get_string('criteriarequiredany', 'completion');
+            $completionview->aggregationmethod = get_string('criteriarequiredany', 'completion');
         }
-
         // Prepare markup for mustache template and get section infos
-        for ($i = 0; $i <= count($modinfo->get_sections()); $i++){
+        for ($i = 0; $i <= count($modinfo->get_sections()); $i++) {
             $sectionname = get_section_name($course, $i);
-            array_push($completion_view->sections, ["name" => $sectionname, "criterias" => []]);
+            array_push($completionview->sections, ["name" => $sectionname, "criterias" => []]);
         }
-        
-        // Loop through completions and handle different criteria types
-        $activity_count = 0;
-        $prerequisites_count = 0;
-        $roles_count = 0;
-        $activity_completed_count = 0;
-        $prerequisites_completed_count = 0;
-        $roles_completed_count = 0;
-        foreach ($completions as $key => $completion){
+        // Loop through completions and handle different criteria types.
+        $activitycount = 0;
+        $prerequisitescount = 0;
+        $rolescount = 0;
+        $activitycompletedcount = 0;
+        $prerequisitescompletedcount = 0;
+        $rolescompletedcount = 0;
+        foreach ($completions as $key => $completion) {
             $criteria = $completion->get_criteria();
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_GRADE){
-                $completion_view->has_grade->enabled = true;
-                $completion_view->has_grade->grade = $completion->get_status();
-                $completion_view->has_grade->complete = $completion->is_complete();
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_GRADE) {
+                $completionview->hasgrade->enabled = true;
+                $completionview->hasgrade->grade = $completion->get_status();
+                $completionview->hasgrade->complete = $completion->is_complete();
             }
-
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_ACTIVITY){
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_ACTIVITY) {
                 // $cmid and $cm needed to get belonging section
-                ++$activity_count;
-                $completion_view->has_activities = true;
+                ++$activitycount;
+                $completionview->hasactivities = true;
                 $cmid = $criteria->moduleinstance;
                 $cm = $modinfo->get_cm($cmid);
-                if($info->get_aggregation_method($criteria->criteriatype) == COMPLETION_AGGREGATION_ALL){
-                    $completion_view->activities_agg_all = true;
-                }
-                else{
-                    $completion_view->activities_agg_any = true;
+                if ($info->get_aggregation_method($criteria->criteriatype) == COMPLETION_AGGREGATION_ALL) {
+                    $completionview->activitiesaggall = true;
+                } else {
+                    $completionview->activitiesaggany = true;
                 }
                 $row = array();
                 $row['type'] = ucfirst($criteria->module);
                 $row['status'] = $completion->get_status();
                 $row['complete'] = $completion->is_complete();
-                if ($completion->is_complete()){
-                    ++$activity_completed_count;
+                if ($completion->is_complete()) {
+                    ++$activitycompletedcount;
                 }
-                $row['timecompleted'] = $completion->timecompleted ? userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
+                $row['timecompleted'] = $completion->timecompleted ?
+                        userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
                 $details = $criteria->get_details($completion);
                 $row['requirement'] = $details["requirement"];
                 $row['criteria'] = $details['criteria'];
-                array_push($completion_view->sections[$cm->sectionnum]["criterias"], $row);
+                array_push($completionview->sections[$cm->sectionnum]["criterias"], $row);
             }
 
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_COURSE){
-                $completion_view->has_prerequisites = true;
-                ++$prerequisites_count;
-                if($info->get_aggregation_method($criteria->criteriatype) == COMPLETION_AGGREGATION_ALL){
-                    $completion_view->prerequisites_agg_all = true;
-                }
-                else{
-                    $completion_view->prerequisites_agg_any = true;
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_COURSE) {
+                $completionview->hasprerequisites = true;
+                ++$prerequisitescount;
+                if ($info->get_aggregation_method($criteria->criteriatype) == COMPLETION_AGGREGATION_ALL) {
+                    $completionview->prerequisitesaggall = true;
+                } else {
+                    $completionview->prerequisitesaggany = true;
                 }
                 $row = array();
                 $row['status'] = $completion->get_status();
                 $row['complete'] = $completion->is_complete();
-                if ($completion->is_complete()){
-                    ++$prerequisites_completed_count;
+                if ($completion->is_complete()) {
+                    ++$prerequisitescompletedcount;
                 }
-                $row['timecompleted'] = $completion->timecompleted ? userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
+                $row['timecompleted'] = $completion->timecompleted ?
+                        userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
                 $details = $criteria->get_details($completion);
                 $row['requirement'] = $details["requirement"];
-                $row['criteria'] = $details['criteria'];  
-                array_push($completion_view->prerequisites, $row);           
+                $row['criteria'] = $details['criteria'];
+                array_push($completionview->prerequisites, $row);
             }
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_DATE){
-                $completion_view->has_date = true;
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_DATE) {
+                $completionview->hasdate = true;
                 $row = array();
                 $row['status'] = $completion->get_status();
                 $row['complete'] = $completion->is_complete();
@@ -608,53 +605,56 @@ class certificate {
                 $row['type'] = $details['type'];
                 $row['criteria'] = $details['criteria'];
                 $row['requirement'] = $details['requirement'];
-                $row['timecompleted'] = $completion->timecompleted ? userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
-                array_push($completion_view->dates, $row);
+                $row['timecompleted'] = $completion->timecompleted ?
+                        userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
+                array_push($completionview->dates, $row);
             }
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_ROLE){
-                $completion_view->has_role = true;
-                ++$roles_count;
-                if($info->get_aggregation_method($criteria->criteriatype) == COMPLETION_AGGREGATION_ALL){
-                    $completion_view->roles_agg_all = true;
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_ROLE) {
+                $completionview->hasrole = true;
+                ++$rolescount;
+                if ($info->get_aggregation_method($criteria->criteriatype) == COMPLETION_AGGREGATION_ALL) {
+                    $completionview->rolesaggall = true;
+                } else {
+                    $completionview->rolesaggany = true;
                 }
-                else{
-                    $completion_view->roles_agg_any = true;
-                }                
                 $row = array();
                 $row['status'] = $completion->get_status();
                 $row['complete'] = $completion->is_complete();
-                if ($completion->is_complete()){
-                    ++$roles_completed_count;
-                }                
+                if ($completion->is_complete()) {
+                    ++$rolescompletedcount;
+                }
                 $details = $criteria->get_details($completion);
                 $row['type'] = $details['type'];
                 $row['criteria'] = $details['criteria'];
                 $row['requirement'] = $details['requirement'];
-                $row['timecompleted'] = $completion->timecompleted ? userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
-                array_push($completion_view->roles, $row);
+                $row['timecompleted'] = $completion->timecompleted ?
+                        userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
+                array_push($completionview->roles, $row);
             }
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_SELF){
-                $completion_view->has_selfcompletion = true;
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_SELF) {
+                $completionview->hasselfcompletion = true;
                 $row = array();
                 $row['complete'] = $completion->is_complete();
                 $details = $criteria->get_details($completion);
                 $row['type'] = $details['type'];
                 $row['requirement'] = $details['requirement'];
-                $row['timecompleted'] = $completion->timecompleted ? userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
-                array_push($completion_view->selfcompletions, $row);
+                $row['timecompleted'] = $completion->timecompleted ?
+                        userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
+                array_push($completionview->selfcompletions, $row);
             }
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_UNENROL){
-                $completion_view->has_unenrol = true;
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_UNENROL) {
+                $completionview->hasunenrol = true;
                 $row = array();
                 $row['complete'] = $completion->is_complete();
                 $details = $criteria->get_details($completion);
                 $row['type'] = $details['type'];
                 $row['requirement'] = $details['requirement'];
-                $row['timecompleted'] = $completion->timecompleted ? userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
-                array_push($completion_view->unenrol, $row);
+                $row['timecompleted'] = $completion->timecompleted ?
+                        userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
+                array_push($completionview->unenrol, $row);
             }
-            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_DURATION){
-                $completion_view->has_duration = true;
+            if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_DURATION) {
+                $completionview->hasduration = true;
                 $row = array();
                 $row['status'] = $completion->get_status();
                 $row['complete'] = $completion->is_complete();
@@ -662,66 +662,56 @@ class certificate {
                 $row['type'] = $details['type'];
                 $row['criteria'] = $details['criteria'];
                 $row['requirement'] = $details['requirement'];
-                $row['timecompleted'] = $completion->timecompleted ? userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
-                array_push($completion_view->durations, $row);
-            }
-
-        }
-        // We need to decide now based on activity completion aggregation if 
-        // activity criteria is completed 
-        // 1. Case: All activities need to be completed
-        if ($completion_view->activities_agg_all && 
-            ($activity_count == $activity_completed_count))
-        {
-            $completion_view->activities_completed = true;
-        } 
-        // 2. Case: Any activity needs to be completed
-        else if ($completion_view->activities_agg_any && 
-                 $activity_completed_count)
-        {
-            $completion_view->activities_completed = true;
-        }
-        // Otherwise $completion_view->activites_completed remains false.
-
-        // We need to decide based on course prerequisites completion aggregation
-        // if prerequisites are fulfilled
-        // 1. Case: All prerequisites need to be completed
-        if ($completion_view->prerequisites_agg_all && 
-            ($prerequisites_count == $prerequisites_completed_count))
-        {
-            $completion_view->prerequisites_completed = true;
-        } 
-        // 2. Case: Any prerequisite needs to be completed
-        else if ($completion_view->prerequisites_agg_any && 
-                 $prerequisites_completed_count)
-        {
-            $completion_view->prerequisites_completed = true;
-        }
-        // We need to decide based on manually completion by other roles
-        // if this criteria is fulfilled
-        // 1. Case: All roles need to confirm
-        if ($completion_view->roles_agg_all && 
-            ($roles_count == $roles_completed_count))
-        {
-            $completion_view->roles_completed = true;
-        } 
-        // 2. Case: Any role needs to confirm
-        else if ($completion_view->roles_agg_any && 
-                 $roles_completed_count)
-        {
-            $completion_view->roles_completed = true;
-        }        
-
-        // Remove sections from output if no activity/criteria was added
-        foreach ($completion_view->sections as $key => $section){
-            if (!count($section["criterias"])){
-                unset($completion_view->sections[$key]);
+                $row['timecompleted'] = $completion->timecompleted ?
+                        userdate($completion->timecompleted, get_string('strftimedate', 'langconfig')) : 0;
+                array_push($completionview->durations, $row);
             }
         }
-        
+        // We need to decide now based on activity completion aggregation,
+        // if activity criteria is completed.
+        // 1. Case: All activities need to be completed.
+        if ($completionview->activitiesaggall &&
+                ($activitycount == $activitycompletedcount)) {
+            $completionview->activitiescompleted = true;
+        } // 2. Case: Any activity needs to be completed.
+        else if ($completionview->activitiesaggany &&
+                $activitycompletedcount) {
+            $completionview->activitiescompleted = true;
+        }
+        // Otherwise $completionview->activites_completed remains false.
+
+        // We need to decide based on course prerequisites completion aggregation,
+        // if prerequisites are fulfilled.
+        // 1. Case: All prerequisites need to be completed.
+        if ($completionview->prerequisitesaggall &&
+                ($prerequisitescount == $prerequisitescompletedcount)) {
+            $completionview->prerequisitescompleted = true;
+        } // 2. Case: Any prerequisite needs to be completed
+        else if ($completionview->prerequisitesaggany &&
+                $prerequisitescompletedcount) {
+            $completionview->prerequisitescompleted = true;
+        }
+        // We need to decide based on manually completion by other roles,
+        // if this criteria is fulfilled.
+        // 1. Case: All roles need to confirm.
+        if ($completionview->rolesaggall &&
+                ($rolescount == $rolescompletedcount)) {
+            $completionview->rolescompleted = true;
+        } // 2. Case: Any role needs to confirm.
+        else if ($completionview->rolesaggany &&
+                $rolescompletedcount) {
+            $completionview->rolescompleted = true;
+        }
+
+        // Remove sections from output if no activity/criteria was added.
+        foreach ($completionview->sections as $key => $section) {
+            if (!count($section["criterias"])) {
+                unset($completionview->sections[$key]);
+            }
+        }
         $renderer = $PAGE->get_renderer('mod_customcert');
         // Reindex array_values for mustache templates
-        $completion_view->sections = array_values($completion_view->sections);
-        return $renderer->render_from_template('mod_customcert/completion_view', $completion_view);
+        $completionview->sections = array_values($completionview->sections);
+        return $renderer->render_from_template('mod_customcert/completionview', $completionview);
     }
 }

--- a/classes/certificate.php
+++ b/classes/certificate.php
@@ -461,17 +461,19 @@ class certificate {
 
         return $code;
     }
+
     /**
      * Checks if a course is completed by current user.
      *
      * @param int $course The course to be checked.
      * @return bool true if completed, otherwise false
      */
-    public static function is_course_completed($course){
+    public static function is_course_completed($course) {
         global $USER;
         $info = new \completion_info($course);
         return $info->is_course_complete($USER->id);
     }
+
     /**
      * Fetches the completions
      *
@@ -523,14 +525,14 @@ class certificate {
         $completionview->hasunenrol = false;
         $completionview->unenrol = array();
 
-        // Check for aggregation method
+        // Check for aggregation method.
         $overall = $info->get_aggregation_method();
         if ($overall == COMPLETION_AGGREGATION_ALL) {
             $completionview->aggregationmethod = get_string('criteriarequiredall', 'completion');
         } else {
             $completionview->aggregationmethod = get_string('criteriarequiredany', 'completion');
         }
-        // Prepare markup for mustache template and get section infos
+        // Prepare markup for mustache template and get section infos.
         for ($i = 0; $i <= count($modinfo->get_sections()); $i++) {
             $sectionname = get_section_name($course, $i);
             array_push($completionview->sections, ["name" => $sectionname, "criterias" => []]);
@@ -550,7 +552,7 @@ class certificate {
                 $completionview->hasgrade->complete = $completion->is_complete();
             }
             if ($criteria->criteriatype == COMPLETION_CRITERIA_TYPE_ACTIVITY) {
-                // $cmid and $cm needed to get belonging section
+                // $cmid and $cm needed to get belonging section.
                 ++$activitycount;
                 $completionview->hasactivities = true;
                 $cmid = $criteria->moduleinstance;
@@ -670,11 +672,11 @@ class certificate {
         // We need to decide now based on activity completion aggregation,
         // if activity criteria is completed.
         // 1. Case: All activities need to be completed.
+        // 2. Case: Any activity needs to be completed.
         if ($completionview->activitiesaggall &&
                 ($activitycount == $activitycompletedcount)) {
             $completionview->activitiescompleted = true;
-        } // 2. Case: Any activity needs to be completed.
-        else if ($completionview->activitiesaggany &&
+        } else if ($completionview->activitiesaggany &&
                 $activitycompletedcount) {
             $completionview->activitiescompleted = true;
         }
@@ -683,22 +685,22 @@ class certificate {
         // We need to decide based on course prerequisites completion aggregation,
         // if prerequisites are fulfilled.
         // 1. Case: All prerequisites need to be completed.
+        // 2. Case: Any prerequisite needs to be completed.
         if ($completionview->prerequisitesaggall &&
                 ($prerequisitescount == $prerequisitescompletedcount)) {
             $completionview->prerequisitescompleted = true;
-        } // 2. Case: Any prerequisite needs to be completed
-        else if ($completionview->prerequisitesaggany &&
+        } else if ($completionview->prerequisitesaggany &&
                 $prerequisitescompletedcount) {
             $completionview->prerequisitescompleted = true;
         }
         // We need to decide based on manually completion by other roles,
         // if this criteria is fulfilled.
         // 1. Case: All roles need to confirm.
+        // 2. Case: Any role needs to confirm.
         if ($completionview->rolesaggall &&
                 ($rolescount == $rolescompletedcount)) {
             $completionview->rolescompleted = true;
-        } // 2. Case: Any role needs to confirm.
-        else if ($completionview->rolesaggany &&
+        } else if ($completionview->rolesaggany &&
                 $rolescompletedcount) {
             $completionview->rolescompleted = true;
         }

--- a/db/access.php
+++ b/db/access.php
@@ -164,4 +164,13 @@ $capabilities = array(
         ),
         'clonepermissionsfrom' => 'moodle/course:manageactivities'
     ),
+    'mod/customcert:managerequiredcompletion' => array(
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => array(
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        ),
+        'clonepermissionsfrom' => 'moodle/course:manageactivities'
+    ),
 );

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -164,20 +164,18 @@ function xmldb_customcert_upgrade($oldversion) {
         $dbman->add_key($table, $key);
 
         upgrade_mod_savepoint(true, 2019111803, 'customcert');
-
-        if ($oldversion < 2019111813) {
-            $table = new xmldb_table('customcert');
-            $field = new xmldb_field('requiredcompletion', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', null);
-
-            // Alter the 'element' column to be characters, rather than text.
-            // Conditionally launch add field.
-            if (!$dbman->field_exists($table, $field)) {
-                $dbman->add_field($table, $field);
-            }
-            // Savepoint reached.
-            upgrade_mod_savepoint(true, 2019111813, 'customcert');
-        }
-
-        return true;
     }
+    if ($oldversion < 2019111813) {
+        $table = new xmldb_table('customcert');
+        $field = new xmldb_field('requiredcompletion', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', null);
+
+        // Alter the 'element' column to be characters, rather than text.
+        // Conditionally launch add field.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        // Savepoint reached.
+        upgrade_mod_savepoint(true, 2019111813, 'customcert');
+    }
+    return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -146,5 +146,18 @@ function xmldb_customcert_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2018051705, 'customcert');
     }
 
+    if ($oldversion < 2019111813) {
+        $table = new xmldb_table('customcert');
+        $field = new xmldb_field('requiredcompletion', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', null);
+
+        // Alter the 'element' column to be characters, rather than text.
+        // Conditionally launch add field.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        // Savepoint reached.
+        upgrade_mod_savepoint(true, 2019111813, 'customcert');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -110,7 +110,7 @@ function xmldb_customcert_upgrade($oldversion) {
         // Add column for new 'verifycertificateanyone' setting.
         $table = new xmldb_table('customcert');
         $field = new xmldb_field('verifyany', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0',
-            'requiredtime');
+                'requiredtime');
 
         // Conditionally launch add field.
         if (!$dbman->field_exists($table, $field)) {
@@ -165,18 +165,19 @@ function xmldb_customcert_upgrade($oldversion) {
 
         upgrade_mod_savepoint(true, 2019111803, 'customcert');
 
-     if ($oldversion < 2019111813) {
-        $table = new xmldb_table('customcert');
-        $field = new xmldb_field('requiredcompletion', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', null);
+        if ($oldversion < 2019111813) {
+            $table = new xmldb_table('customcert');
+            $field = new xmldb_field('requiredcompletion', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', null);
 
-        // Alter the 'element' column to be characters, rather than text.
-        // Conditionally launch add field.
-        if (!$dbman->field_exists($table, $field)) {
-            $dbman->add_field($table, $field);
+            // Alter the 'element' column to be characters, rather than text.
+            // Conditionally launch add field.
+            if (!$dbman->field_exists($table, $field)) {
+                $dbman->add_field($table, $field);
+            }
+            // Savepoint reached.
+            upgrade_mod_savepoint(true, 2019111813, 'customcert');
         }
-        // Savepoint reached.
-        upgrade_mod_savepoint(true, 2019111813, 'customcert');
-    }
 
-    return true;
+        return true;
+    }
 }

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -32,8 +32,7 @@ $string['certificate'] = 'Certificate';
 $string['code'] = 'Code';
 $string['copy'] = 'Copy';
 $string['coursecompletionreq'] = 'Obtaining certificate requires course to be completed.';
-$string['coursecompletionreq_help'] = 'Certificate is available, if general completion requirements from the course completion settings are fulfilled. 
-In the certificate view, users will have an overview of which requirements are fulfilled or missing.';
+$string['coursecompletionreq_help'] = 'Certificate is available, if general completion requirements from the course completion settings are fulfilled. In the certificate view, users will have an overview of which requirements are fulfilled or missing.';
 $string['coursetimereq'] = 'Required minutes in course';
 $string['coursetimereq_help'] = 'Enter here the minimum amount of time, in minutes, that a student must be logged into the course before they will be able to receive
 the certificate.';

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -44,6 +44,7 @@ $string['customcert:manageemailteachers'] = 'Manage email teachers setting';
 $string['customcert:manageemailothers'] = 'Manage email others setting';
 $string['customcert:manageverifyany'] = 'Manage verification setting';
 $string['customcert:managerequiredtime'] = 'Manage time required setting';
+$string['customcert:managerequiredcompletion'] = 'Manage required course completion setting';
 $string['customcert:manageprotection'] = 'Manage protection setting';
 $string['customcert:receiveissue'] = 'Receive a certificate';
 $string['customcert:view'] = 'View a custom certificate';

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -22,6 +22,8 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+$string['activityaggregation_all'] = 'ALL activities need to be completed.';
+$string['activityaggregation_any'] = 'ANY activity needs to be completed.';
 $string['addcertpage'] = 'Add page';
 $string['addelement'] = 'Add element';
 $string['awardedto'] = 'Awarded to';
@@ -29,6 +31,9 @@ $string['cannotverifyallcertificates'] = 'You do not have the permission to veri
 $string['certificate'] = 'Certificate';
 $string['code'] = 'Code';
 $string['copy'] = 'Copy';
+$string['coursecompletionreq'] = 'Obtaining certificate requires course to be completed.';
+$string['coursecompletionreq_help'] = 'Certificate is available, if general completion requirements from the course completion settings are fulfilled. 
+In the certificate view, users will have an overview of which requirements are fulfilled or missing.';
 $string['coursetimereq'] = 'Required minutes in course';
 $string['coursetimereq_help'] = 'Enter here the minimum amount of time, in minutes, that a student must be logged into the course before they will be able to receive
 the certificate.';
@@ -139,6 +144,8 @@ $string['posx'] = 'Position X';
 $string['posx_help'] = 'This is the position in mm from the top left corner you wish the element\'s reference point to locate in the x direction.';
 $string['posy'] = 'Position Y';
 $string['posy_help'] = 'This is the position in mm from the top left corner you wish the element\'s reference point to locate in the y direction.';
+$string['prerequisiteaggregation_all'] = 'ALL courses need to be completed.';
+$string['prerequisiteaggregation_any'] = 'ANY course needs to be completed.';
 $string['preventcopy'] = 'Prevent copy';
 $string['preventcopy_desc'] = 'Enable protection from copy action.';
 $string['preventprint'] = 'Prevent print';
@@ -157,10 +164,13 @@ $string['rearrangeelementsheading'] = 'Drag and drop elements to change where th
 $string['receiveddate'] = 'Awarded on';
 $string['refpoint'] = 'Reference point location';
 $string['refpoint_help'] = 'The reference point is the location of an element from which its x and y coordinates are determined. It is indicated by the \'+\' that appears in the centre or corners of the element.';
+$string['remainingdays'] = 'Remaining days';
 $string['replacetemplate'] = 'Replace';
 $string['requiredtimenotmet'] = 'You must spend at least a minimum of {$a->requiredtime} minutes in the course before you can access this certificate.';
 $string['rightmargin'] = 'Right margin';
 $string['rightmargin_help'] = 'This is the right margin of the certificate PDF in mm.';
+$string['roleaggregation_all'] = 'ALL roles need to manually complete.';
+$string['roleaggregation_any'] = 'ANY role needs to manually complete.';
 $string['save'] = 'Save';
 $string['saveandclose'] = 'Save and close';
 $string['saveandcontinue'] = 'Save and continue';

--- a/mod_form.php
+++ b/mod_form.php
@@ -109,7 +109,7 @@ class mod_customcert_mod_form extends moodleform_mod {
             $firstoption = empty($firstoption) ? 'protection_print' : $firstoption;
         }
         if (has_capability('mod/customcert:managerequiredcompletion', $this->get_context())) {
-            $mform->addElement('selectyesno','requiredcompletion',get_string('coursecompletionreq', 'customcert'));
+            $mform->addElement('selectyesno', 'requiredcompletion', get_string('coursecompletionreq', 'customcert'));
             $mform->addHelpButton('requiredcompletion', 'coursecompletionreq', 'customcert');
             $mform->setDefault('requiredcompletion', get_config('customcert', 'requiredcompletion'));
             $mform->setType('requiredcompletion', PARAM_INT);

--- a/mod_form.php
+++ b/mod_form.php
@@ -108,6 +108,13 @@ class mod_customcert_mod_form extends moodleform_mod {
             $mform->setType('protection_copy', PARAM_BOOL);
             $firstoption = empty($firstoption) ? 'protection_print' : $firstoption;
         }
+        if (has_capability('mod/customcert:managerequiredcompletion', $this->get_context())) {
+            $mform->addElement('selectyesno','requiredcompletion',get_string('coursecompletionreq', 'customcert'));
+            $mform->addHelpButton('requiredcompletion', 'coursecompletionreq', 'customcert');
+            $mform->setDefault('requiredcompletion', get_config('customcert', 'requiredcompletion'));
+            $mform->setType('requiredcompletion', PARAM_INT);
+            $firstoption = empty($firstoption) ? 'requiredcompletion' : $firstoption;
+        }
 
         if (!empty($firstoption)) {
             $mform->insertElementBefore($optionsheader, $firstoption);

--- a/settings.php
+++ b/settings.php
@@ -83,6 +83,10 @@ $settings->add(new admin_setting_configcheckbox('customcert/protection_copy',
     get_string('preventcopy_desc', 'customcert'),
     0));
 
+$settings->add(new admin_setting_configselect('customcert/requiredcompletion',
+    get_string('coursecompletionreq', 'customcert'), get_string('coursecompletionreq_help', 'customcert'),
+    0, $yesnooptions));    
+
 $ADMIN->add('customcert', $settings);
 
 // Element plugin settings.

--- a/settings.php
+++ b/settings.php
@@ -84,8 +84,7 @@ $settings->add(new admin_setting_configcheckbox('customcert/protection_copy',
     0));
 
 $settings->add(new admin_setting_configselect('customcert/requiredcompletion',
-    get_string('coursecompletionreq', 'customcert'), get_string('coursecompletionreq_help', 'customcert'),
-    0, $yesnooptions));    
+    get_string('coursecompletionreq', 'customcert'), get_string('coursecompletionreq_help', 'customcert'), 0, $yesnooptions));
 
 $ADMIN->add('customcert', $settings);
 

--- a/templates/completion_view.mustache
+++ b/templates/completion_view.mustache
@@ -1,0 +1,350 @@
+<div class="row mt-5">
+  <div class="col-12 py-3 h5 text-light bg-info">
+    <i class="fa fa-question-circle"></i>
+    {{# str}} overallaggregation, completion {{/ str }}: 
+    {{ aggregation_method }}.
+  </div>
+</div>
+
+{{# has_role }}
+  <div class="row my-4 border" id="{{ uniqid }}-completionreq">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{# str }} manualcompletionby, completion {{/ str}}
+      </div>
+    {{# roles_completed}}
+      <div class="col-12 py-2 mb-2 text-light bg-success">
+        <i class="fa fa-check"></i>
+        {{# str}} completion-y, completion {{/ str}}.
+        {{# roles_agg_all}} 
+          {{# str}} roleaggregation_all, customcert {{/ str}}
+        {{/ roles_agg_all}}
+        {{# roles_agg_any}}
+          {{# str}} roleaggregation_any, customcert {{/ str}}
+        {{/ roles_agg_any}}        
+      </div>
+    {{/ roles_completed}}
+    {{^ roles_completed}}
+      <div class="col-12 py-2 mb-2 text-light bg-danger">
+        <i class="fa fa-times"></i>
+        {{# str}} completion-n, completion {{/ str}}.
+        {{# roles_agg_all}} 
+          {{# str}} roleaggregation_all, customcert {{/ str}}
+        {{/ roles_agg_all}}
+        {{# roles_agg_any}}
+          {{# str}} roleaggregation_any, customcert {{/ str}}
+        {{/ roles_agg_any}}
+      </div>
+    {{/ roles_completed}}    
+
+    <div class="col-2 py-2 h6 font-weight-bold text-center">
+      {{# str }} status, core {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold">
+      {{# str }} role, core {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold text-break">
+      {{# str }} requirement, block_completionstatus {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold">
+      {{# str }} completiondate, report_completion {{/ str }}
+    </div>
+    {{# roles }}
+      <div class="col-2 py-2 d-flex align-items-center justify-content-center">
+        {{# complete }}
+          <div class="py-2 px-3 bg-success text-light">
+            <i class="fa fa-check"></i> 
+          </div>
+        {{/ complete }}
+        {{^ complete}}
+          <div class="py-2 px-3 bg-danger text-light">
+            <i class="fa fa-times"></i> 
+          </div>
+        {{/ complete}}
+      </div>
+      <div class="col-3 py-3 d-flex align-items-center">
+        {{{ criteria }}}
+      </div>
+      <div class="col-3 py-3 d-flex align-items-center">
+        {{ requirement }}
+      </div>
+      <div class="col-3 py-3 d-flex align-items-center">
+        {{# timecompleted }} {{ timecompleted }} {{/ timecompleted}}
+      </div>
+    {{/ roles }}
+  </div>
+{{/ has_role }}
+
+{{# has_unenrol }}
+  {{# unenrol }}
+    <div class="row my-4 border">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{ type }}
+      </div>
+      <div class="col-12 py-2 text-light
+                  {{# complete }} bg-success {{/ complete }}
+                  {{^ complete }} bg-danger {{/ complete }}">
+        {{# complete }}
+          <i class="fa fa-check"></i>
+          {{# str}} completion-y, completion {{/ str}}.
+          {{# str }} requiredcriteria, completion {{/ str}}: {{ requirement }}.
+        {{/ complete }}
+        {{^ complete }}
+          <i class="fa fa-times"></i>
+          {{# str}} completion-n, completion {{/ str}}.
+          {{# str}} requiredcriteria, completion {{/ str}}: 
+          {{ requirement }}.
+        {{/ complete }}        
+
+      </div>
+    </div>
+  {{/ unenrol }}
+{{/ has_unenrol }}
+
+{{# has_selfcompletion }}
+  {{# selfcompletions }}
+    <div class="row my-4 border">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{ type }}
+      </div>
+      <div class="col-12 py-2 text-light
+                  {{# complete }} bg-success {{/ complete }}
+                  {{^ complete }} bg-danger {{/ complete }}">
+        {{# complete }}
+          <i class="fa fa-check"></i>
+          {{# str}} completion-y, completion {{/ str}}.
+          {{# str }} requiredcriteria, completion {{/ str}}: {{ requirement }}.
+        {{/ complete }}
+        {{^ complete }}
+          <i class="fa fa-times"></i>
+          {{# str}} completion-n, completion {{/ str}}.
+          {{# str}} requiredcriteria, completion {{/ str}}: 
+          {{ requirement }}.
+        {{/ complete }}        
+
+      </div>
+    </div>
+  {{/ selfcompletions }}
+{{/ has_selfcompletion }}
+
+{{# has_duration }}
+  {{# durations }}
+    <div class="row my-4 border">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{ criteria }}
+      </div>
+      <div class="col-12 py-2 text-light
+                  {{# complete }} bg-success {{/ complete }}
+                  {{^ complete }} bg-danger {{/ complete }}">
+        {{# complete }}
+          <i class="fa fa-check"></i>
+          {{# str}} completion-y, completion {{/ str}}.
+          {{# str }} requiredcriteria, completion {{/ str}}: {{ requirement }}
+        {{/ complete }}
+        {{^ complete }}
+          <i class="fa fa-times"></i>
+          {{# str}} completion-n, completion {{/ str}}.
+          {{# str}} remainingdays, customcert {{/ str}}: 
+          {{ status }}
+        {{/ complete }}        
+
+      </div>
+    </div>
+  {{/ durations }}
+{{/ has_duration }}
+
+{{# has_date }}
+  {{# dates }}
+    <div class="row my-4 border">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{ criteria }}
+      </div>
+      <div class="col-12 py-2 text-light
+                  {{# complete }} bg-success {{/ complete }}
+                  {{^ complete }} bg-danger {{/ complete }}">
+        {{# complete }}
+          <i class="fa fa-check"></i>
+          {{# str}} completion-y, completion {{/ str}}.
+        {{/ complete }}
+        {{^ complete }}
+          <i class="fa fa-times"></i>
+          {{# str}} completion-n, completion {{/ str}}.
+        {{/ complete }}        
+        {{# str }} requiredcriteria, completion {{/ str}}: {{ requirement }}
+      </div>
+    </div>
+  {{/ dates }}
+{{/ has_date }}
+
+{{# has_grade }}
+  {{# enabled }}
+    <div class="row my-4 border">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{# str }} grade, core {{/ str}}
+      </div>
+      <div class="col-12 py-2 text-light
+                  {{# complete }} bg-success {{/ complete }}
+                  {{^ complete }} bg-danger {{/ complete }}">
+        {{# complete }}
+          <i class="fa fa-check"></i>
+          {{# str}} completion-y, completion {{/ str}}.
+        {{/ complete }}
+        {{^ complete }}
+          <i class="fa fa-times"></i>
+          {{# str}} completion-n, completion {{/ str}}.
+        {{/ complete }}        
+        {{# str }} coursegrade, completion {{/ str}}: {{grade}}
+      </div>
+    </div>
+  {{/ enabled }}
+{{/ has_grade }}
+
+
+{{# has_prerequisites }}
+  <div class="row my-4 border" id="{{ uniqid }}-completionreq">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{# str }} dependenciescompleted, completion {{/ str}}
+      </div>
+    {{# prerequisites_completed}}
+      <div class="col-12 py-2 mb-2 text-light bg-success">
+        <i class="fa fa-check"></i>
+        {{# str}} completion-y, completion {{/ str}}.
+        {{# prerequisites_agg_all}} 
+          {{# str}} prerequisiteaggregation_all, customcert {{/ str}}
+        {{/ prerequisites_agg_all}}
+        {{# prerequisites_agg_any}}
+          {{# str}} prerequisiteaggregation_any, customcert {{/ str}}
+        {{/ prerequisites_agg_any}}        
+      </div>
+    {{/ prerequisites_completed}}
+    {{^ prerequisites_completed}}
+      <div class="col-12 py-2 mb-2 text-light bg-danger">
+        <i class="fa fa-times"></i>
+        {{# str}} completion-n, completion {{/ str}}.
+        {{# prerequisites_agg_all}} 
+          {{# str}} prerequisiteaggregation_all, customcert {{/ str}}
+        {{/ prerequisites_agg_all}}
+        {{# prerequisites_agg_any}}
+          {{# str}} prerequisiteaggregation_any, customcert {{/ str}}
+        {{/ prerequisites_agg_any}}
+      </div>
+    {{/ prerequisites_completed}}    
+
+    <div class="col-2 py-2 h6 font-weight-bold text-center">
+      {{# str }} status, core {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold">
+      {{# str }} course, core {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold text-break">
+      {{# str }} requirement, block_completionstatus {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold">
+      {{# str }} completiondate, report_completion {{/ str }}
+    </div>
+    {{# prerequisites }}
+      <div class="col-2 py-2 d-flex align-items-center justify-content-center">
+        {{# complete }}
+          <div class="py-2 px-3 bg-success text-light">
+            <i class="fa fa-check"></i> 
+          </div>
+        {{/ complete }}
+        {{^ complete}}
+          <div class="py-2 px-3 bg-danger text-light">
+            <i class="fa fa-times"></i> 
+          </div>
+        {{/ complete}}
+      </div>
+      <div class="col-3 py-3 d-flex align-items-center">
+        {{{ criteria }}}
+      </div>
+      <div class="col-3 py-3 d-flex align-items-center">
+        {{ requirement }}
+      </div>
+      <div class="col-3 py-3 d-flex align-items-center">
+        {{# timecompleted }} {{ timecompleted }} {{/ timecompleted}}
+      </div>
+    {{/ prerequisites }}
+  </div>
+{{/ has_prerequisites }}
+
+
+{{# has_activities }}
+  <div class="row my-4 border" id="{{ uniqid }}-completionreq">
+      <div class="col-12 py-3 h4 bg-light">
+        <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
+        {{# str }} activity, core {{/ str}}
+      </div>
+    {{# activities_completed}}
+      <div class="col-12 py-2 mb-2 text-light bg-success">
+        <i class="fa fa-check"></i>
+        {{# str}} completion-y, completion {{/ str}}.
+        {{# activities_agg_all}} 
+          {{# str}} activityaggregation_all, customcert {{/ str}}
+        {{/ activities_agg_all}}
+        {{# activities_agg_any}}
+          {{# str}} activityaggregation_any, customcert {{/ str}}
+        {{/ activities_agg_any}}        
+      </div>
+    {{/ activities_completed}}
+    {{^ activities_completed}}
+      <div class="col-12 py-2 mb-2 text-light bg-danger">
+        <i class="fa fa-times"></i>
+        {{# str}} completion-n, completion {{/ str}}.
+        {{# activities_agg_all}} 
+          {{# str}} activityaggregation_all, customcert {{/ str}}
+        {{/ activities_agg_all}}
+        {{# activities_agg_any}}
+          {{# str}} activityaggregation_any, customcert {{/ str}}
+        {{/ activities_agg_any}}
+      </div>
+    {{/ activities_completed}}    
+
+    <div class="col-2 py-2 h6 font-weight-bold text-center">
+      {{# str }} status, core {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold">
+      {{# str }} activity, core {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold text-break">
+      {{# str }} requirement, block_completionstatus {{/ str }}
+    </div>
+    <div class="col-3 py-2 h6 font-weight-bold">
+      {{# str }} completiondate, report_completion {{/ str }}
+    </div>
+    {{# sections }}
+      <div class="col-12 py-2 bg-light">
+        <h6>{{ name }}</h6>
+      </div>
+      {{# criterias }}
+        <div class="col-2 py-2 d-flex align-items-center justify-content-center">
+          {{# complete }}
+            <div class="py-2 px-3 bg-success text-light">
+              <i class="fa fa-check"></i> 
+            </div>
+          {{/ complete }}
+          {{^ complete}}
+            <div class="py-2 px-3 bg-danger text-light">
+              <i class="fa fa-times"></i> 
+            </div>
+          {{/ complete}}
+        </div>
+        <div class="col-3 py-3 d-flex align-items-center">
+          <small class="text-muted pr-2 d-none d-sm-block">{{ type }}:</small> {{{ criteria }}}
+        </div>
+        <div class="col-3 py-3 d-flex align-items-center">
+          {{ requirement }}
+        </div>
+        <div class="col-3 py-3 d-flex align-items-center">
+          {{# timecompleted }} {{ timecompleted }} {{/ timecompleted}}
+        </div>      
+      {{/ criterias }}
+    {{/ sections }}
+  </div>
+{{/ has_activities }}

--- a/templates/completion_view.mustache
+++ b/templates/completion_view.mustache
@@ -1,41 +1,135 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_customcert/completion_view
+
+    The overview for course completion on customcert view
+
+    Classes required for JS:
+    * None
+
+    Data attibutes required for JS:
+    * All data attributes are required
+
+    Context variables required for this template:
+    * aggregationmethod
+    * hasrole
+        * rolescompleted
+            * rolesaggall
+            * rolesaggany
+        * roles
+            * complete
+            * criteria
+            * requirement
+            * timecompleted
+    * hasunenrol
+        * unenrol
+            * type
+            * complete
+            * requirement
+    * hasselfcompletion
+        * selfcompletions
+            * type
+            * complete
+            * requirement
+    * hasduration
+        * durations
+            * criteria
+            * complete
+            * criteria
+            * status
+    * hasdate
+        * dates
+            * criteria
+            * complete
+            * requirement
+    * hasgrade
+        * enabled
+            * complete
+            * grade
+    * hasprerequisites
+        * prerequisitescompleted
+            * prerequisitesaggall
+            * prerequisitesaggany
+        * prerequisites
+            * complete
+            * criteria
+            * requirement
+            * timecompleted
+     * hasactivities
+        * activitiescompleted
+            * activitiesaggall
+            * activitiesaggany
+        * sections
+            * name
+            * criterias
+                * complete
+                * type
+                * criteria
+                * requirement
+                * timecompleted
+
+    Example context (json):
+    {
+        "emailgreeting": "Dear Angus MacGyver",
+        "emailbody": "Attached is your certificate 'The basics' for the course 'Survival as an '80s action hero'",
+        "emailcertificatelink": "http://yoursite.com/mod/customcert/view.php?id=4",
+        "emailcertificatelinktext": "Certificate report"
+    }
+}}
+
 <div class="row mt-5">
   <div class="col-12 py-3 h5 text-light bg-info">
     <i class="fa fa-question-circle"></i>
     {{# str}} overallaggregation, completion {{/ str }}: 
-    {{ aggregation_method }}.
+    {{ aggregationmethod }}.
   </div>
 </div>
 
-{{# has_role }}
+{{# hasrole }}
   <div class="row my-4 border" id="{{ uniqid }}-completionreq">
       <div class="col-12 py-3 h4 bg-light">
         <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
         {{# str }} manualcompletionby, completion {{/ str}}
       </div>
-    {{# roles_completed}}
+    {{# rolescompleted}}
       <div class="col-12 py-2 mb-2 text-light bg-success">
         <i class="fa fa-check"></i>
         {{# str}} completion-y, completion {{/ str}}.
-        {{# roles_agg_all}} 
+        {{# rolesaggall}} 
           {{# str}} roleaggregation_all, customcert {{/ str}}
-        {{/ roles_agg_all}}
-        {{# roles_agg_any}}
+        {{/ rolesaggall}}
+        {{# rolesaggany}}
           {{# str}} roleaggregation_any, customcert {{/ str}}
-        {{/ roles_agg_any}}        
+        {{/ rolesaggany}}        
       </div>
-    {{/ roles_completed}}
-    {{^ roles_completed}}
+    {{/ rolescompleted}}
+    {{^ rolescompleted}}
       <div class="col-12 py-2 mb-2 text-light bg-danger">
         <i class="fa fa-times"></i>
         {{# str}} completion-n, completion {{/ str}}.
-        {{# roles_agg_all}} 
+        {{# rolesaggall}} 
           {{# str}} roleaggregation_all, customcert {{/ str}}
-        {{/ roles_agg_all}}
-        {{# roles_agg_any}}
+        {{/ rolesaggall}}
+        {{# rolesaggany}}
           {{# str}} roleaggregation_any, customcert {{/ str}}
-        {{/ roles_agg_any}}
+        {{/ rolesaggany}}
       </div>
-    {{/ roles_completed}}    
+    {{/ rolescompleted}}    
 
     <div class="col-2 py-2 h6 font-weight-bold text-center">
       {{# str }} status, core {{/ str }}
@@ -73,9 +167,9 @@
       </div>
     {{/ roles }}
   </div>
-{{/ has_role }}
+{{/ hasrole }}
 
-{{# has_unenrol }}
+{{# hasunenrol }}
   {{# unenrol }}
     <div class="row my-4 border">
       <div class="col-12 py-3 h4 bg-light">
@@ -95,14 +189,13 @@
           {{# str}} completion-n, completion {{/ str}}.
           {{# str}} requiredcriteria, completion {{/ str}}: 
           {{ requirement }}.
-        {{/ complete }}        
-
+        {{/ complete }}
       </div>
     </div>
   {{/ unenrol }}
-{{/ has_unenrol }}
+{{/ hasunenrol }}
 
-{{# has_selfcompletion }}
+{{# hasselfcompletion }}
   {{# selfcompletions }}
     <div class="row my-4 border">
       <div class="col-12 py-3 h4 bg-light">
@@ -127,9 +220,9 @@
       </div>
     </div>
   {{/ selfcompletions }}
-{{/ has_selfcompletion }}
+{{/ hasselfcompletion }}
 
-{{# has_duration }}
+{{# hasduration }}
   {{# durations }}
     <div class="row my-4 border">
       <div class="col-12 py-3 h4 bg-light">
@@ -149,14 +242,13 @@
           {{# str}} completion-n, completion {{/ str}}.
           {{# str}} remainingdays, customcert {{/ str}}: 
           {{ status }}
-        {{/ complete }}        
-
+        {{/ complete }}
       </div>
     </div>
   {{/ durations }}
-{{/ has_duration }}
+{{/ hasduration }}
 
-{{# has_date }}
+{{# hasdate }}
   {{# dates }}
     <div class="row my-4 border">
       <div class="col-12 py-3 h4 bg-light">
@@ -178,9 +270,9 @@
       </div>
     </div>
   {{/ dates }}
-{{/ has_date }}
+{{/ hasdate }}
 
-{{# has_grade }}
+{{# hasgrade }}
   {{# enabled }}
     <div class="row my-4 border">
       <div class="col-12 py-3 h4 bg-light">
@@ -202,39 +294,39 @@
       </div>
     </div>
   {{/ enabled }}
-{{/ has_grade }}
+{{/ hasgrade }}
 
 
-{{# has_prerequisites }}
+{{# hasprerequisites }}
   <div class="row my-4 border" id="{{ uniqid }}-completionreq">
       <div class="col-12 py-3 h4 bg-light">
         <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
         {{# str }} dependenciescompleted, completion {{/ str}}
       </div>
-    {{# prerequisites_completed}}
+    {{# prerequisitescompleted}}
       <div class="col-12 py-2 mb-2 text-light bg-success">
         <i class="fa fa-check"></i>
         {{# str}} completion-y, completion {{/ str}}.
-        {{# prerequisites_agg_all}} 
+        {{# prerequisitesaggall}} 
           {{# str}} prerequisiteaggregation_all, customcert {{/ str}}
-        {{/ prerequisites_agg_all}}
-        {{# prerequisites_agg_any}}
+        {{/ prerequisitesaggall}}
+        {{# prerequisitesaggany}}
           {{# str}} prerequisiteaggregation_any, customcert {{/ str}}
-        {{/ prerequisites_agg_any}}        
+        {{/ prerequisitesaggany}}        
       </div>
-    {{/ prerequisites_completed}}
-    {{^ prerequisites_completed}}
+    {{/ prerequisitescompleted}}
+    {{^ prerequisitescompleted}}
       <div class="col-12 py-2 mb-2 text-light bg-danger">
         <i class="fa fa-times"></i>
         {{# str}} completion-n, completion {{/ str}}.
-        {{# prerequisites_agg_all}} 
+        {{# prerequisitesaggall}} 
           {{# str}} prerequisiteaggregation_all, customcert {{/ str}}
-        {{/ prerequisites_agg_all}}
-        {{# prerequisites_agg_any}}
+        {{/ prerequisitesaggall}}
+        {{# prerequisitesaggany}}
           {{# str}} prerequisiteaggregation_any, customcert {{/ str}}
-        {{/ prerequisites_agg_any}}
+        {{/ prerequisitesaggany}}
       </div>
-    {{/ prerequisites_completed}}    
+    {{/ prerequisitescompleted}}    
 
     <div class="col-2 py-2 h6 font-weight-bold text-center">
       {{# str }} status, core {{/ str }}
@@ -272,39 +364,39 @@
       </div>
     {{/ prerequisites }}
   </div>
-{{/ has_prerequisites }}
+{{/ hasprerequisites }}
 
 
-{{# has_activities }}
+{{# hasactivities }}
   <div class="row my-4 border" id="{{ uniqid }}-completionreq">
       <div class="col-12 py-3 h4 bg-light">
         <small class="text-muted pr-2">{{# str}} criteria, completion {{/ str}}</small>
         {{# str }} activity, core {{/ str}}
       </div>
-    {{# activities_completed}}
+    {{# activitiescompleted}}
       <div class="col-12 py-2 mb-2 text-light bg-success">
         <i class="fa fa-check"></i>
         {{# str}} completion-y, completion {{/ str}}.
-        {{# activities_agg_all}} 
+        {{# activitiesaggall}} 
           {{# str}} activityaggregation_all, customcert {{/ str}}
-        {{/ activities_agg_all}}
-        {{# activities_agg_any}}
+        {{/ activitiesaggall}}
+        {{# activitiesaggany}}
           {{# str}} activityaggregation_any, customcert {{/ str}}
-        {{/ activities_agg_any}}        
+        {{/ activitiesaggany}}        
       </div>
-    {{/ activities_completed}}
-    {{^ activities_completed}}
+    {{/ activitiescompleted}}
+    {{^ activitiescompleted}}
       <div class="col-12 py-2 mb-2 text-light bg-danger">
         <i class="fa fa-times"></i>
         {{# str}} completion-n, completion {{/ str}}.
-        {{# activities_agg_all}} 
+        {{# activitiesaggall}} 
           {{# str}} activityaggregation_all, customcert {{/ str}}
-        {{/ activities_agg_all}}
-        {{# activities_agg_any}}
+        {{/ activitiesaggall}}
+        {{# activitiesaggany}}
           {{# str}} activityaggregation_any, customcert {{/ str}}
-        {{/ activities_agg_any}}
+        {{/ activitiesaggany}}
       </div>
-    {{/ activities_completed}}    
+    {{/ activitiescompleted}}    
 
     <div class="col-2 py-2 h6 font-weight-bold text-center">
       {{# str }} status, core {{/ str }}
@@ -347,4 +439,4 @@
       {{/ criterias }}
     {{/ sections }}
   </div>
-{{/ has_activities }}
+{{/ hasactivities }}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
-$plugin->version   = 2019111802; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2019111816; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019111800; // Requires this Moodle version (3.8).
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_customcert';

--- a/view.php
+++ b/view.php
@@ -66,7 +66,7 @@ $completionreq = '';
 if ($customcert->requiredcompletion) {
     $completionreq_rendered = \mod_customcert\certificate::get_completion_requirements($course);
     
-    if (\mod_customcert\certificate::is_course_completed($course)){
+    if (\mod_customcert\certificate::is_course_completed($course) || $canmanage){
         $completionreq = $completionreq_rendered;
     }
     else{

--- a/view.php
+++ b/view.php
@@ -63,7 +63,7 @@ if ($customcert->requiredtime && !$canmanage) {
 
 // Check if the user can view the certificate based on required course completion.
 $completionreq = '';
-if ($customcert->requiredcompletion) {
+if (property_exists($customcert, 'requiredcompletion') && $customcert->requiredcompletion) {
     $completionreqrendered = \mod_customcert\certificate::get_completion_requirements($course);
     if (\mod_customcert\certificate::is_course_completed($course) || $canmanage) {
         $completionreq = $completionreqrendered;

--- a/view.php
+++ b/view.php
@@ -61,21 +61,17 @@ if ($customcert->requiredtime && !$canmanage) {
     }
 }
 
-// Check if the user can view the certificate based on required course completion
+// Check if the user can view the certificate based on required course completion.
 $completionreq = '';
 if ($customcert->requiredcompletion) {
-    $completionreq_rendered = \mod_customcert\certificate::get_completion_requirements($course);
-    
-    if (\mod_customcert\certificate::is_course_completed($course) || $canmanage){
-        $completionreq = $completionreq_rendered;
-    }
-    else{
-        notice($completionreq_rendered, "$CFG->wwwroot/course/view.php?id=$course->id");
+    $completionreqrendered = \mod_customcert\certificate::get_completion_requirements($course);
+    if (\mod_customcert\certificate::is_course_completed($course) || $canmanage) {
+        $completionreq = $completionreqrendered;
+    } else {
+        notice($completionreqrendered, "$CFG->wwwroot/course/view.php?id=$course->id");
         die;
-    }    
+    }
 }
-
-
 // Check if we are deleting an issue.
 if ($deleteissue && $canmanage && confirm_sesskey()) {
     if (!$confirm) {

--- a/view.php
+++ b/view.php
@@ -61,6 +61,21 @@ if ($customcert->requiredtime && !$canmanage) {
     }
 }
 
+// Check if the user can view the certificate based on required course completion
+$completionreq = '';
+if ($customcert->requiredcompletion) {
+    $completionreq_rendered = \mod_customcert\certificate::get_completion_requirements($course);
+    
+    if (\mod_customcert\certificate::is_course_completed($course)){
+        $completionreq = $completionreq_rendered;
+    }
+    else{
+        notice($completionreq_rendered, "$CFG->wwwroot/course/view.php?id=$course->id");
+        die;
+    }    
+}
+
+
 // Check if we are deleting an issue.
 if ($deleteissue && $canmanage && confirm_sesskey()) {
     if (!$confirm) {
@@ -148,6 +163,7 @@ if (!$downloadown && !$downloadissue) {
     echo $OUTPUT->header();
     echo $OUTPUT->heading(format_string($customcert->name));
     echo $intro;
+    echo $completionreq;
     echo $issuehtml;
     echo $downloadbutton;
     if (isset($reporttable)) {


### PR DESCRIPTION
I've added an option for the CustomCert which prints an overview for missing/fulfilled tasks depending on the logic from the core functionality _Course Completion_. There is no custom styling, everything was done with Bootstrap4, which is integrated in the Moodle Core.

## How to use it?
Enable Completion tracking in the course settings and then tick the option _Obtaining certificate requires course to be completed_ in the Customcert activity. In the course settings _Course Completion_ it is possible to determine the conditions when a course is completed (e.g. to obtain a specific course grade, have all activities done and more). All this settings are then reflected in the view from the certificate (see screenshot below).

## Important
This view is based on the core logic of _Course completion_, which works with cronjobs for updating Completion Info. So be sure when using this option to have your cronjobs configured properly. There is a [ticket](https://tracker.moodle.org/browse/MDL-32103) (unfortunately back from 2012) about moving the course completion out of the cron, but I think this won't happen so fast (maybe in Moodle 3.9 or 4.0?).

![image](https://user-images.githubusercontent.com/22622792/73928748-e70e6100-48d3-11ea-8a04-132fcef78624.png)
