### PR TITLE
Add new element to display course short name

### DIFF
--- a/element/courseshortname/classes/element.php
+++ b/element/courseshortname/classes/element.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of the customcert module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file contains the customcert element courseshortname's core interaction API.
+ *
+ * @package    customcertelement_courseshortname
+ * @copyright  2013 Mark Nelson <markn@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace customcertelement_courseshortname;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * The customcert element courseshortname's core interaction API.
+ *
+ * @package    customcertelement_courseshortname
+ * @copyright  2013 Mark Nelson <markn@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class element extends \mod_customcert\element {
+
+    /**
+     * Handles rendering the element on the pdf.
+     *
+     * @param \pdf $pdf the pdf object
+     * @param bool $preview true if it is a preview, false otherwise
+     * @param \stdClass $user the user we are rendering this for
+     */
+    public function render($pdf, $preview, $user) {
+        \mod_customcert\element_helper::render_content($pdf, $this, $this->get_course_shortname());
+    }
+
+    /**
+     * Render the element in html.
+     *
+     * This function is used to render the element when we are using the
+     * drag and drop interface to position it.
+     *
+     * @return string the html
+     */
+    public function render_html() {
+        return \mod_customcert\element_helper::render_html_content($this, $this->get_course_shortname());
+    }
+
+    /**
+     * Helper function that returns the category name.
+     *
+     * @return string
+     */
+    protected function get_course_shortname() {
+        $courseid = \mod_customcert\element_helper::get_courseid($this->get_id());
+        $course = get_course($courseid);
+        $context = \mod_customcert\element_helper::get_context($this->get_id());
+
+        return format_string($course->shortname, true, ['context' => $context]);
+    }
+}

--- a/element/courseshortname/classes/privacy/provider.php
+++ b/element/courseshortname/classes/privacy/provider.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for customcertelement_courseshortname.
+ *
+ * @package    customcertelement_courseshortname
+ * @copyright  2018 Mark Nelson <markn@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace customcertelement_courseshortname\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Privacy Subsystem for customcertelement_courseshortname implementing null_provider.
+ *
+ * @copyright  2018 Mark Nelson <markn@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason() {
+        return 'privacy:metadata';
+    }
+}

--- a/element/courseshortname/lang/en/customcertelement_courseshortname.php
+++ b/element/courseshortname/lang/en/customcertelement_courseshortname.php
@@ -1,0 +1,26 @@
+<?php
+// This file is part of the customcert module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component 'customcertelement_courseshortname', language 'en'.
+ *
+ * @package    customcertelement_courseshortname
+ * @copyright  2013 Mark Nelson <markn@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['pluginname'] = 'Course short name';
+$string['privacy:metadata'] = 'The Course short name plugin does not store any personal data.';

--- a/element/courseshortname/version.php
+++ b/element/courseshortname/version.php
@@ -1,0 +1,29 @@
+<?php
+// This file is part of the customcert module for Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file contains the version information for the courseshortname plugin.
+ *
+ * @package    customcertelement_courseshortname
+ * @copyright  2013 Mark Nelson <markn@moodle.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
+
+$plugin->version   = 2017050500; // The current module version (Date: YYYYMMDDXX).
+$plugin->requires  = 2017050500; // Requires this Moodle version (3.3).
+$plugin->component = 'customcertelement_courseshortname';


### PR DESCRIPTION
This element is based on the coursename element, and provides the ability to display the course shortname on certificates