### PR TITLE
Add support for the horizontal alignment of elements

### DIFF
--- a/classes/element.php
+++ b/classes/element.php
@@ -38,6 +38,21 @@ defined('MOODLE_INTERNAL') || die();
 abstract class element {
 
     /**
+     * @var string The left alignment constant.
+     */
+    const ALIGN_LEFT = 'L';
+
+    /**
+     * @var string The centered alignment constant.
+     */
+    const ALIGN_CENTER = 'C';
+
+    /**
+     * @var string The right alignment constant.
+     */
+    const ALIGN_RIGHT = 'R';
+    
+    /**
      * @var \stdClass $element The data for the element we are adding - do not use, kept for legacy reasons.
      */
     protected $element;
@@ -98,6 +113,11 @@ abstract class element {
     protected $refpoint;
 
     /**
+     * @var string The alignment.
+     */
+    protected $alignment;
+
+    /**
      * @var bool $showposxy Show position XY form elements?
      */
     protected $showposxy;
@@ -130,6 +150,7 @@ abstract class element {
         $this->width = $element->width;
         $this->refpoint = $element->refpoint;
         $this->showposxy = isset($showposxy) && $showposxy;
+        $this->set_alignment(isset($element->alignment) ? $element->alignment : element::ALIGN_LEFT);
     }
 
     /**
@@ -232,6 +253,30 @@ abstract class element {
     }
 
     /**
+     * Returns the alignment.
+     * 
+     * @return string The current alignment value.
+     */
+    public function get_alignment() {
+        return isset($this->alignment) ? $this->alignment : element::ALIGN_LEFT;
+    }
+
+    /**
+     * Sets the alignment.
+     * 
+     * @param string $alignment The new alignment.
+     * 
+     * @throws InvalidArgumentException if the provided new alignment is not valid.
+     */
+    protected function set_alignment($alignment) {
+        $valid_values = array(element::ALIGN_LEFT, element::ALIGN_CENTER, element::ALIGN_RIGHT);
+        if (!in_array($alignment, $valid_values)) {
+            throw new \InvalidArgumentException("'$alignment' is not a valid alignment value. It has to be one of " . implode(', ', $valid_values));
+        }
+        $this->alignment = $alignment;
+    }
+
+    /**
      * This function renders the form elements when adding a customcert element.
      * Can be overridden if more functionality is needed.
      *
@@ -246,6 +291,7 @@ abstract class element {
         }
         element_helper::render_form_element_width($mform);
         element_helper::render_form_element_refpoint($mform);
+        element_helper::render_form_element_alignment($mform);
     }
 
     /**
@@ -265,7 +311,8 @@ abstract class element {
             'posx' => $this->posx,
             'posy' => $this->posy,
             'width' => $this->width,
-            'refpoint' => $this->refpoint
+            'refpoint' => $this->refpoint,
+            'alignment' => $this->get_alignment()
         ];
         foreach ($properties as $property => $value) {
             if (!is_null($value) && $mform->elementExists($property)) {
@@ -320,6 +367,7 @@ abstract class element {
         }
         $element->width = (isset($data->width)) ? $data->width : null;
         $element->refpoint = (isset($data->refpoint)) ? $data->refpoint : null;
+        $element->alignment = (isset($data->alignment)) ? $data->alignment : element::ALIGN_LEFT;
         $element->timemodified = time();
 
         // Check if we are updating, or inserting a new element.

--- a/classes/element_factory.php
+++ b/classes/element_factory.php
@@ -59,6 +59,7 @@ class element_factory {
         $data->posy = isset($element->posy) ? $element->posy : null;
         $data->width = isset($element->width) ? $element->width : null;
         $data->refpoint = isset($element->refpoint) ? $element->refpoint : null;
+        $data->alignment = isset($element->alignment) ? $element->alignment : null;
 
         // Ensure the necessary class exists.
         if (class_exists($classname)) {

--- a/classes/element_helper.php
+++ b/classes/element_helper.php
@@ -74,6 +74,7 @@ class element_helper {
         $w = $element->get_width();
         $refpoint = $element->get_refpoint();
         $actualwidth = $pdf->GetStringWidth($content);
+        $alignment = $element->get_alignment();
 
         if ($w and $w < $actualwidth) {
             $actualwidth = $w;
@@ -104,7 +105,7 @@ class element_helper {
             $w += 0.0001;
         }
         $pdf->setCellPaddings(0, 0, 0, 0);
-        $pdf->writeHTMLCell($w, 0, $x, $y, $content, 0, 0, false, true);
+        $pdf->writeHTMLCell($w, 0, $x, $y, $content, 0, 0, false, true, $alignment);
     }
 
     /**
@@ -203,6 +204,23 @@ class element_helper {
         $mform->setType('refpoint', PARAM_INT);
         $mform->setDefault('refpoint', self::CUSTOMCERT_REF_POINT_TOPCENTER);
         $mform->addHelpButton('refpoint', 'refpoint', 'customcert');
+    }
+
+    /**
+     * Helper function to render the alignment form element.
+     *
+     * @param \MoodleQuickForm $mform the edit_form instance.
+     */
+    public static function render_form_element_alignment($mform) {
+        $alignmentoptions = array();
+        $alignmentoptions[element::ALIGN_LEFT] = get_string('alignleft', 'customcert');
+        $alignmentoptions[element::ALIGN_CENTER] = get_string('aligncenter', 'customcert');
+        $alignmentoptions[element::ALIGN_RIGHT] = get_string('alignright', 'customcert');
+        
+        $mform->addElement('select', 'alignment', get_string('alignment', 'customcert'), $alignmentoptions);
+        $mform->setType('alignment', PARAM_ALPHA);
+        $mform->setDefault('alignment', element::ALIGN_LEFT);
+        $mform->addHelpButton('alignment', 'alignment', 'customcert');
     }
 
     /**

--- a/db/install.xml
+++ b/db/install.xml
@@ -84,6 +84,7 @@
         <FIELD NAME="posy" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="width" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="refpoint" TYPE="int" LENGTH="4" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="alignment" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="L" SEQUENCE="false"/>
         <FIELD NAME="sequence" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -166,5 +166,14 @@ function xmldb_customcert_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2019111803, 'customcert');
     }
 
+    if ($oldversion < 2019111803) { // Replace with the actual version number.
+        $table = new xmldb_table('customcert_elements');
+        $field = new xmldb_field('alignment', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, 'L', 'refpoint');
+
+        $dbman->add_field($table, $field);
+
+        upgrade_mod_savepoint(true, 2019111803, 'customcert'); // Replace with the actual version number.
+    }
+
     return true;
 }

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -25,6 +25,11 @@
 $string['activity'] = 'Activity';
 $string['addcertpage'] = 'Add page';
 $string['addelement'] = 'Add element';
+$string['aligncenter'] = 'Centered';
+$string['alignleft'] = 'Left alignment';
+$string['alignment'] = 'Alignment';
+$string['alignment_help'] = 'This property sets the horizontal alignment of the element. Some elements may not support this, while the behaviour of others may differ.';
+$string['alignright'] = 'Right alignment';
 $string['awardedto'] = 'Awarded to';
 $string['cannotverifyallcertificates'] = 'You do not have the permission to verify all certificates on the site.';
 $string['certificate'] = 'Certificate';

--- a/rearrange.php
+++ b/rearrange.php
@@ -112,6 +112,18 @@ if ($elements) {
                 default:
                     $class = 'element refpoint-left';
             }
+            switch ($element->alignment) {
+                case \mod_customcert\element::ALIGN_CENTER:
+                    $class .= ' align-center';
+                    break;
+                case \mod_customcert\element::ALIGN_RIGHT:
+                    $class .= ' align-right';
+                    break;
+                case \mod_customcert\element::ALIGN_LEFT:
+                default:
+                    $class .= ' align-left';
+                    break;
+            }
             $html .= html_writer::tag('div', $e->render_html(), array('class' => $class,
                 'data-refpoint' => $element->refpoint, 'id' => 'element-' . $element->id));
         }

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,18 @@
     margin: -4px -5px -5px 4px;
 }
 
+#page-mod-customcert-rearrange .element.align-left {
+    text-align: left;
+}
+
+#page-mod-customcert-rearrange .element.align-center {
+    text-align: center;
+}
+
+#page-mod-customcert-rearrange .element.align-right {
+    text-align: right;
+}
+
 #page-mod-customcert-rearrange #pdf {
     border-style: solid;
     border-width: 1px;


### PR DESCRIPTION
This PR allows to specify the horizontal alignment of elements on a per-element basis, as requested in the issue #121 

Note this applies only to the alignment of the contents of the elements. The element itself still needs to be manually placed in the page. Also, whether the alignment will occur in the end or not depends on the element type itself; some elements may not support horizontal alignment of their contents.

Adds a new field `alignment` in the `customcert_elements` table, defaulting to `'L'`. This can be edited in the element edition form.

No version numbers were changed, although the addition is clearly separated in `db/upgrade.php` so it's just a matter of using the final version number there.

There are still slight discrepancies between the arrangement editor and the final rendering. This is because the rendering collapses the elements' width and then does the element alignment based on this width and the element anchor (reference) point, whereas the arrangement editor uses the configured element width. Thus, small elements (e.g., non-wrapping texts) are rendered centered although the editor displays it using the full width. This is beyond the scope of this PR.