### PR TITLE
Add actions title to elements table

### DIFF
--- a/classes/edit_form.php
+++ b/classes/edit_form.php
@@ -247,7 +247,7 @@ class edit_form extends \moodleform {
             // Create a table to display these elements.
             $table = new \html_table();
             $table->attributes = array('class' => 'generaltable elementstable');
-            $table->head  = array(get_string('name', 'customcert'), get_string('type', 'customcert'), '');
+            $table->head  = array(get_string('name', 'customcert'), get_string('type', 'customcert'), get_string('actions'));
             $table->align = array('left', 'left', 'left');
             // Loop through and add the elements to the table.
             foreach ($elements as $element) {


### PR DESCRIPTION
Hi @mdjnelson ,
Our users found a minor issue in the element table because the third column doesn't have a title, so the htm_table create this column as TD, not a TH.
Could we add the Actions title to the third column so that it is consistent with other tables in Moodle?

![Before](https://user-images.githubusercontent.com/42837030/120128023-42601300-c1eb-11eb-8a2c-9e8346329552.PNG)
![After](https://user-images.githubusercontent.com/42837030/120128028-455b0380-c1eb-11eb-8ff0-cf088abfc2e3.PNG)
