### PR TITLE
Closes #449 The user id should be mapped to the equivalent user id in new sites during activity restore

### DIFF
--- a/backup/moodle2/restore_customcert_stepslib.php
+++ b/backup/moodle2/restore_customcert_stepslib.php
@@ -159,6 +159,7 @@ class restore_customcert_activity_structure_step extends restore_activity_struct
 
         $data->customcertid = $this->get_new_parentid('customcert');
         $data->timecreated = $this->apply_date_offset($data->timecreated);
+        $data->userid = $this->get_mappingid('user', $data->userid);
 
         $newitemid = $DB->insert_record('customcert_issues', $data);
         $this->set_mapping('customcert_issue', $oldid, $newitemid);


### PR DESCRIPTION
As the userid in the customcert_issues table were using the userid from the site where the activity was backed up, emails were being sent to those that had already received them. Theoretically there wwere also users who should have received an email who didn't get one.