### PR TITLE
Extraction of private digital signature parameters to external configuration

### DIFF
--- a/element/digitalsignature/version.php
+++ b/element/digitalsignature/version.php
@@ -24,6 +24,6 @@
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
-$plugin->version   = 2019111800; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2021092200; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019111800; // Requires this Moodle version (3.8).
 $plugin->component = 'customcertelement_digitalsignature';


### PR DESCRIPTION
To preserve the privacy of critical parts of the digital signature (_private key_ and _password_), this patch allows to configure them externally in the site configuration (i.e., `config.php` and the like).

Two new configuration parameters are introduced, `customcert_signature_private_keys` and `customcert_signature_passwords`. Both are associative arrays with a similar structure. Their values are the value/location of the private keys and the passwords, respectively. Their keys are the `context_id` of the digital signature element instances. If no such key is found, a wildcard key `'*'` is looked for (useful, for instance, when the whole site will share the same signing certificate configuration). If none of them is defined, falls back to the previous behaviour (i.e., configured by editing the element in the site administration interface).