### PR TITLE
Stop using deprecated pipe coreToLocaleString

### DIFF
--- a/templates/mobile_view_activity_page_latest.mustache
+++ b/templates/mobile_view_activity_page_latest.mustache
@@ -89,7 +89,7 @@
                 <br />
                 <div class="timerewarded">
                     <%#issue%>
-                        {{ <% timecreated %> | coreToLocaleString }}
+                        {{ <% timecreated %> * 1000 | coreFormatDate }}
                     <%/issue%>
                     <%^issue%>
                         {{ 'plugin.mod_customcert.notissued' | translate }}
@@ -139,7 +139,7 @@
                 <ion-label>
                     <% displayname %>
                     <br />
-                    <div class="timerewarded">{{ <% timecreated %> | coreToLocaleString }}</div>
+                    <div class="timerewarded">{{ <% timecreated %> * 1000 | coreFormatDate }}</div>
                 </ion-label>
                 <div slot="end" class="flex-row">
                     <ion-button fill="clear" [core-download-file]="{fileurl: '<% fileurl %>', timemodified: '<% currenttimestamp %>'}" moduleId="<% cmid %>" courseId="<% certificate.course %>" component="mod_customcert" [attr.aria-label]="'core.download' | translate">


### PR DESCRIPTION
This pipe has been deprecated for a while and will be removed in a near future, breaking the plugin if it still uses it.