### PR TITLE
521 Fix: title and description shown twice

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
-$plugin->version   = 2021051702; // The current module version (Date: YYYYMMDDXX).
-$plugin->requires  = 2021051700; // Requires this Moodle version (3.11).
+$plugin->version   = 2021051703; // The current module version (Date: YYYYMMDDXX).
+$plugin->requires  = 2022041900; // Requires this Moodle version (4.00).
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_customcert';
 
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = "3.11.1"; // User-friendly version number.
+$plugin->release   = "4.00.0"; // User-friendly version number.

--- a/view.php
+++ b/view.php
@@ -119,12 +119,6 @@ if (!$downloadown && !$downloadissue) {
         }
     }
 
-    // Generate the intro content if it exists.
-    $intro = '';
-    if (!empty($customcert->intro)) {
-        $intro = $OUTPUT->box(format_module_intro('customcert', $customcert, $cm->id), 'generalbox', 'intro');
-    }
-
     // If the current user has been issued a customcert generate HTML to display the details.
     $issuehtml = '';
     $issues = $DB->get_records('customcert_issues', array('userid' => $USER->id, 'customcertid' => $customcert->id));
@@ -147,8 +141,6 @@ if (!$downloadown && !$downloadissue) {
 
     // Output all the page data.
     echo $OUTPUT->header();
-    echo $OUTPUT->heading(format_string($customcert->name));
-    echo $intro;
     echo $issuehtml;
     echo $downloadbutton;
     if (isset($reporttable)) {


### PR DESCRIPTION
Removed code to show this activity's title and description as this is handled by the activity header class in Moodle 4.0 (see MDL-72413 and https://moodledev.io/docs/devupdate#the-activity-header-class).

This is a new MOODLE_400_BRANCH with $plugin->requires = 2022041900 because this change is specifically for Moodle 4.0 or later.