### PR TITLE
Fix Unit test

### DIFF
--- a/classes/template.php
+++ b/classes/template.php
@@ -273,7 +273,7 @@ class template {
             $customcert = $DB->get_record('customcert', ['templateid' => $this->id]);
 
             // I want to have my digital diplomas without having to change my preferred language.
-            $userlang = $USER->lang;
+            $userlang = $USER->lang ?? current_language();
             $forcelang = mod_customcert_force_current_language($customcert->language);
             if (!empty($forcelang)) {
                 // This is a failsafe -- if an exception triggers during the template rendering, this should still execute.

--- a/lib.php
+++ b/lib.php
@@ -444,7 +444,7 @@ function mod_customcert_force_current_language($language): bool {
     }
 
     $activelangs = get_string_manager()->get_list_of_translations();
-    $userlang = $USER->lang;
+    $userlang = $USER->lang ?? current_language();
 
     if (array_key_exists($language, $activelangs) && $language != $userlang) {
         force_current_language($language);


### PR DESCRIPTION
Fix  for failing PHPUnit test on 4.1

Undefined property: stdClass::$lang