### PR TITLE
Removed background image from dropdown when there is one already (#550)

### DIFF
--- a/classes/edit_form.php
+++ b/classes/edit_form.php
@@ -241,6 +241,7 @@ class edit_form extends \moodleform {
         $mform->addHelpButton('pagerightmargin_' . $page->id, 'rightmargin', 'customcert');
 
         // Check if there are elements to add.
+        $hasbackground = false;
         if ($elements = $DB->get_records('customcert_elements', array('pageid' => $page->id), 'sequence ASC')) {
             // Get the total number of elements.
             $numelements = count($elements);
@@ -257,6 +258,9 @@ class edit_form extends \moodleform {
                 $row = new \html_table_row();
                 $row->cells[] = $OUTPUT->render($elementname);
                 $row->cells[] = $element->element;
+                if (!$hasbackground && $element->element === 'bgimage') {
+                    $hasbackground = true;
+                }
                 // Link to edit this element.
                 $link = new \moodle_url($editelementlink, $editelementlinkparams + array('id' => $element->id,
                     'action' => 'edit'));
@@ -297,7 +301,7 @@ class edit_form extends \moodleform {
         }
 
         $group = array();
-        $group[] = $mform->createElement('select', 'element_' . $page->id, '', element_helper::get_available_element_types());
+        $group[] = $mform->createElement('select', 'element_' . $page->id, '', element_helper::get_available_element_types($hasbackground));
         $group[] = $mform->createElement('submit', 'addelement_' . $page->id, get_string('addelement', 'customcert'),
             array(), false);
         $mform->addElement('group', 'elementgroup', '', $group, '', false);

--- a/classes/element_helper.php
+++ b/classes/element_helper.php
@@ -434,9 +434,10 @@ class element_helper {
     /**
      * Return the list of possible elements to add.
      *
+     * @param boolean $skipbackground whether to skip the background image
      * @return array the list of element types that can be used.
      */
-    public static function get_available_element_types() {
+    public static function get_available_element_types(bool $skipbackground = false) {
         global $CFG;
 
         // Array to store the element types.
@@ -449,8 +450,9 @@ class element_helper {
             $elementfolders = new \DirectoryIterator($elementdir);
             // Loop through the elements folder.
             foreach ($elementfolders as $elementfolder) {
-                // If it is not a directory or it is '.' or '..', skip it.
-                if (!$elementfolder->isDir() || $elementfolder->isDot()) {
+                // If it is not a directory or it is '.' or '..', or skip background, skip it.
+                if (!$elementfolder->isDir() || $elementfolder->isDot()
+                    || (substr($elementfolder->getPathname(), -7) === 'bgimage' && $skipbackground)) {
                     continue;
                 }
                 // Check that the standard class exists, if not we do


### PR DESCRIPTION
This PR creates a new variable `$skipbackground` to skip adding the background image to the element dropdown, when there is already one background image in a template