### PR TITLE
571 Delete customcert_pages rows after elements

### DIFF
--- a/classes/template.php
+++ b/classes/template.php
@@ -215,11 +215,6 @@ class template {
         // Get the page.
         $page = $DB->get_record('customcert_pages', array('id' => $pageid), '*', MUST_EXIST);
 
-        // Delete this page.
-        $DB->delete_records('customcert_pages', array('id' => $page->id));
-
-        \mod_customcert\event\page_deleted::create_from_page($page, $this)->trigger();
-
         // The element may have some extra tasks it needs to complete to completely delete itself.
         if ($elements = $DB->get_records('customcert_elements', array('pageid' => $page->id))) {
             foreach ($elements as $element) {
@@ -232,6 +227,11 @@ class template {
                 }
             }
         }
+
+        // Delete this page.
+        $DB->delete_records('customcert_pages', array('id' => $page->id));
+
+        \mod_customcert\event\page_deleted::create_from_page($page, $this)->trigger();
 
         // Now we want to decrease the page number values of
         // the pages that are greater than the page we deleted.

--- a/tests/page_test.php
+++ b/tests/page_test.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Contains tests for template's page operations.
+ *
+ * @package   mod_customcert
+ * @copyright 2023 Leon Stringer <leon.stringer@ntlworld.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_customcert\event;
+
+/**
+ * Contains tests for template's page operations.
+ *
+ * @package   mod_customcert
+ * @copyright 2023 Leon Stringer <leon.stringer@ntlworld.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class page_test extends \advanced_testcase {
+    public function setUp(): void {
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Check deleting a non-empty page has no errors.
+     *   1. Create a template.
+     *   2. Add a second page.
+     *   3. Add an element to the second page.
+     *   4. Delete the second page.
+     * Previously the above scenario resulted in an error (#571).
+     */
+    public function test_delete_non_empty_page(): void {
+	global $DB;
+
+        $template = \mod_customcert\template::create('Test name', \context_system::instance()->id);
+
+	// Add a second page and add an element to it.
+        $page2id = $template->add_page();
+        $element = new \stdClass();
+        $element->pageid = $page2id;
+        $element->name = 'Image';
+        $element->element = 'image';
+        $elementid = $DB->insert_record('customcert_elements', $element);
+
+        $template->delete_page($page2id);
+
+	$records = $DB->get_records('customcert_elements', array('pageid' => $page2id));
+        $this->assertCount(0, $records);
+
+	$records = $DB->get_records('customcert_pages', array('id' => $page2id));
+        $this->assertCount(0, $records);
+    }
+}


### PR DESCRIPTION
Previously template->delete_page() deleted the corresponding mdl_customcert_pages row, and then called element->delete() for each element on the page.  But the latter then called
element_deleted::create_from_element() which relied on that mdl_customcert_pages row to obtain the contextid for the event.

Now element->delete() is called for each element on the page, then the mdl_customcert_pages row is deleted.