### PR TITLE
#565 Fix undefined external_format_text error in mobile app

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -24,6 +24,8 @@
 
 namespace mod_customcert\output;
 
+require_once($CFG->libdir . '/externallib.php');
+
 /**
  * Mobile output class for the custom certificate.
  *


### PR DESCRIPTION
This error was caused by this change in Moodle LMS:

https://tracker.moodle.org/browse/MDL-76583