### PR TITLE
Ensure events are only triggered when necessary

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -173,7 +173,7 @@ if ($data = $mform->get_data()) {
         $template = \mod_customcert\template::create($data->name, $contextid);
 
         // Create a page for this template.
-        $pageid = $template->add_page();
+        $pageid = $template->add_page(false);
 
         // Associate all the data from the form to the newly created page.
         $width = 'pagewidth_' . $pageid;

--- a/load_template.php
+++ b/load_template.php
@@ -51,22 +51,11 @@ if ($template->get_context()->contextlevel == CONTEXT_MODULE) {
 // Check that they have confirmed they wish to load the template.
 if ($confirm && confirm_sesskey()) {
     // First, remove all the existing elements and pages.
-    $sql = "SELECT e.*
-              FROM {customcert_elements} e
-        INNER JOIN {customcert_pages} p
-                ON e.pageid = p.id
-             WHERE p.templateid = :templateid";
-    if ($elements = $DB->get_records_sql($sql, array('templateid' => $template->get_id()))) {
-        foreach ($elements as $element) {
-            // Get an instance of the element class.
-            if ($e = \mod_customcert\element_factory::get_element_instance($element)) {
-                $e->delete();
-            }
+    if ($pages = $DB->get_records('customcert_pages', ['templateid' => $template->get_id()])) {
+        foreach ($pages as $page) {
+            $template->delete_page($page->id, false);
         }
     }
-
-    // Delete the pages.
-    $DB->delete_records('customcert_pages', array('templateid' => $template->get_id()));
 
     // Copy the items across.
     $loadtemplate->copy_to_template($template);


### PR DESCRIPTION
1. Suppress template_updated when creating new template.

2. Fix Save changes/Add element so template_updated triggered if name changed.

3. Fix context for page_created when loading a template in course instance (was system now course module).