### PR TITLE
Add updated events for reposition elements (#599)

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -54,4 +54,7 @@ foreach ($values as $value) {
     $element->posx = $value->posx;
     $element->posy = $value->posy;
     $DB->update_record('customcert_elements', $element);
+    \mod_customcert\event\element_updated::create_from_id($element->id, $template)->trigger();
 }
+
+\mod_customcert\event\template_updated::create_from_template($template)->trigger();

--- a/classes/event/element_updated.php
+++ b/classes/event/element_updated.php
@@ -88,6 +88,23 @@ class element_updated extends \core\event\base {
     }
 
     /**
+     * Create instance of event for the specified element.
+     *
+     * @param int $elementid ID of the element.
+     * @param \mod_customcert\template $template Template containing the above
+     * element.
+     * @return element_updated
+     */
+    public static function create_from_id(int $elementid, \mod_customcert\template $template): element_updated {
+        $data = [
+            'contextid' => $template->get_contextid(),
+            'objectid' => $elementid,
+        ];
+
+        return self::create($data);
+    }
+
+    /**
      * Returns relevant URL.
      * @return \moodle_url
      */


### PR DESCRIPTION
When using drag and drop to reposition elements trigger element_updated and template_updated events on save.