### PR TITLE
Issue #620: use viewreport cap for downloading student certs

### DIFF
--- a/view.php
+++ b/view.php
@@ -99,7 +99,7 @@ if ($groupmode = groups_get_activity_groupmode($cm)) {
 }
 
 // Check if we are downloading all certificates.
-if ($downloadall && $canmanage && confirm_sesskey()) {
+if ($downloadall && $canviewreport && confirm_sesskey()) {
     $template = new \mod_customcert\template($template);
     $issues = \mod_customcert\certificate::get_issues($customcert->id, $groupmode, $cm, 0, 0);
 
@@ -157,7 +157,7 @@ if (!$downloadown && !$downloadissue) {
     $numissues = \mod_customcert\certificate::get_number_of_issues($customcert->id, $cm, $groupmode);
 
     $downloadallbutton = '';
-    if ($canmanage && $numissues > 0) {
+    if ($canviewreport && $numissues > 0) {
         $linkname = get_string('downloadallissuedcertificates', 'customcert');
         $link = new moodle_url('/mod/customcert/view.php',
             [
@@ -183,7 +183,7 @@ if (!$downloadown && !$downloadissue) {
     }
     echo $OUTPUT->footer($course);
     exit();
-} else if ($canreceive || $canmanage) { // Output to pdf.
+} else if ($canreceive || $canviewreport) { // Output to pdf.
     // Set the userid value of who we are downloading the certificate for.
     $userid = $USER->id;
     if ($downloadown) {


### PR DESCRIPTION
As stated in issue #620 there are some inconsistencies in when the download button is shown in the report and when the user can actually download that cert, so non-editing teachers can see the buttons but get sent to a blank page. I've changed it so it consistently uses the `mod/customcert:viewreport` permission for downloading certificates.

If you feel like the `mod/customcert:viewreport` permission shouldn't allow a user to download certificates, I can adjust the change so that the `mod/customcert:manage` permission is required to display the download buttons in `classes/report_table.php`.