### PR TITLE
Issue #629: strip HTML tags when getting string width

### DIFF
--- a/classes/element_helper.php
+++ b/classes/element_helper.php
@@ -73,7 +73,8 @@ class element_helper {
         $y = $element->get_posy();
         $w = $element->get_width();
         $refpoint = $element->get_refpoint();
-        $actualwidth = $pdf->GetStringWidth($content);
+        $cleanedcontent = clean_param($content, PARAM_NOTAGS);
+        $actualwidth = $pdf->GetStringWidth($cleanedcontent);
         $alignment = $element->get_alignment();
 
         if ($w && $w < $actualwidth) {


### PR DESCRIPTION
As described in issue #629 the auto-linking filters can mess up text element positions. The actual width should only be calculated from the content without HTML tags. See the issue for testing instructions.