### PR TITLE
Added ISO 8601 date format.

### DIFF
--- a/classes/element_helper.php
+++ b/classes/element_helper.php
@@ -702,6 +702,7 @@ class element_helper {
         $dateformats = [
             1 => userdate($date, '%B %d, %Y'),
             2 => userdate($date, '%B %d' . $suffix . ', %Y'),
+            5 => userdate($date, '%Y-%m-%d'),
         ];
 
         $strdateformats = [
@@ -758,6 +759,10 @@ class element_helper {
                     break;
                 case 4:
                     $certificatedate = userdate($date, '%B %Y');
+                    break;
+                case 5:
+                    // ISO 8601 date format (YYYY-MM-DD)
+                    $certificatedate = userdate($date, '%Y-%m-%d');
                     break;
                 default:
                     $certificatedate = userdate($date, get_string('strftimedate', 'langconfig'));

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
 $plugin->version   = 2024042206; // The current module version (Date: YYYYMMDDXX).
-$plugin->requires  = 2024042200; // Requires this Moodle version (4.4).
+$plugin->requires  = 2024123000; // Requires this Moodle version (4.4).
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_customcert';
 


### PR DESCRIPTION
This PR fixes #638.

Date option is available "Edit certificate".
<img width="1440" alt="Screenshot 2024-12-29 at 10 14 14 PM" src="https://github.com/user-attachments/assets/057329b7-7931-43ac-b9bb-82909eec274f" />

The same is printed on the certificate.
<img width="797" alt="Screenshot 2024-12-29 at 10 14 40 PM" src="https://github.com/user-attachments/assets/6bea89e9-809b-4814-be03-145f5ae5c64b" />

Related issue:
https://github.com/modern-training-solutions/learn.PacificMedicalTraining.com/issues/89
