### PR TITLE
Support hyphenated digits format

### DIFF
--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -243,3 +243,7 @@ $string['verifycertificateanyone_help'] = 'This setting enables anyone with the 
 $string['verifycertificatedesc'] = 'This link will take you to a new screen where you will be able to verify certificates on the site';
 $string['width'] = 'Width';
 $string['width_help'] = 'This is the width of the certificate PDF in mm. For reference an A4 piece of paper is 210mm wide and a letter is 216mm wide.';
+$string['codegenerationmethod'] = 'Code generation method';
+$string['codegenerationmethod_desc'] = 'Choose between the two methods for generating certificate codes.';
+$string['codegenerationmethod_upperlowerdigits'] = '6aOdbLEuoC (Upper/lower/digits random string)';
+$string['codegenerationmethod_digitshyphens'] = '0123-4567-8901 (Digits with hyphens)';

--- a/settings.php
+++ b/settings.php
@@ -81,6 +81,17 @@ $settings->add(new admin_setting_configduration('customcert/certificateexecution
 $settings->add(new admin_setting_heading('defaults',
     get_string('modeditdefaults', 'admin'), get_string('condifmodeditdefaults', 'admin')));
 
+$settings->add(new admin_setting_configselect(
+    'customcert/codegenerationmethod',
+    get_string('codegenerationmethod', 'customcert'),
+    get_string('codegenerationmethod_desc', 'customcert'),
+    0, // Default option (0 = Upper/lower/digits random string method).
+    [
+        0 => get_string('codegenerationmethod_upperlowerdigits', 'customcert'), // Upper/lower/digits random string.
+        1 => get_string('codegenerationmethod_digitshyphens', 'customcert')  // Digits with hyphens numeric code.
+    ]
+));
+
 $yesnooptions = [
     0 => get_string('no'),
     1 => get_string('yes'),


### PR DESCRIPTION
This additionally adds the ####-####-#### format for certificate codes. Each # is a digit 0-9.

Thank you to @Raza403 for all your help on this issue.

Fixes #668.

https://github.com/user-attachments/assets/a1df302a-5fa9-41e7-bbce-728938a1aaa5