### PR TITLE
Updating subplugins.json file to match latest format

### DIFF
--- a/db/subplugins.json
+++ b/db/subplugins.json
@@ -1,5 +1,9 @@
 {
+    "subplugintypes": {
+        "customcertelement": "element"
+    },
     "plugintypes": {
-        "customcertelement": "mod\/customcert\/element"
+        "customcertelement": "mod/customcert/element"
     }
 }
+


### PR DESCRIPTION
Updating subplugins.json file to match the latest format as mentioned in [MDL-83705](https://tracker.moodle.org/browse/MDL-83705). MDL-83705 mentions that we need to have subplugins defined under the `subplugintypes` object as well as under the `plugintypes` object with its full path. `subplugins.json` of other plugins follow the same format mentioned in MDL-83705. 