### PR TITLE
Prevent duplicate emails on certificate task failure

### DIFF
--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -162,7 +162,7 @@ class email_certificate_task extends \core\task\adhoc_task {
             $DB->set_field('customcert_issues', 'emailed', 1, ['id' => $issueid]);
             mtrace("Marked certificate issue ID $issueid as emailed to prevent retries.");
 
-            // Track email sending results for logging
+            // Track email sending results for logging.
             $emailresults = [];
             $emailfailures = [];
 
@@ -263,7 +263,7 @@ class email_certificate_task extends \core\task\adhoc_task {
                 }
             }
 
-            // Log results
+            // Log results.
             if (!empty($emailresults)) {
                 mtrace("Email successes for issue ID $issueid: " . implode(', ', $emailresults));
             }
@@ -277,7 +277,7 @@ class email_certificate_task extends \core\task\adhoc_task {
                 throw new \moodle_exception("No emails sent successfully for issue ID $issueid; retrying later.");
             }
             $transaction->allow_commit();
-            // Clean up temporary file
+            // Clean up temporary file.
             if (file_exists($tempfile)) {
                 unlink($tempfile);
             }

--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -166,121 +166,121 @@ class email_certificate_task extends \core\task\adhoc_task {
             $emailresults = [];
             $emailfailures = [];
 
-        // Now try to send emails; log any failures but DO NOT retry.
-        if ($customcert->emailstudents) {
-            try {
-                $renderable = new \mod_customcert\output\email_certificate(
+            // Now try to send emails; log any failures but DO NOT retry.
+            if ($customcert->emailstudents) {
+                try {
+                    $renderable = new \mod_customcert\output\email_certificate(
                     true,
                     $userfullname,
                     $courseshortname,
                     $coursefullname,
                     $certificatename,
                     $context->instanceid
-                );
+                    );
 
-                $subject = get_string('emailstudentsubject', 'customcert', $info);
-                $message = $textrenderer->render($renderable);
-                $messagehtml = $htmlrenderer->render($renderable);
+                    $subject = get_string('emailstudentsubject', 'customcert', $info);
+                    $message = $textrenderer->render($renderable);
+                    $messagehtml = $htmlrenderer->render($renderable);
 
-                $result = email_to_user($user, $userfrom, html_entity_decode($subject, ENT_COMPAT), $message,
-                    $messagehtml, $tempfile, $filename);
+                    $result = email_to_user($user, $userfrom, html_entity_decode($subject, ENT_COMPAT), $message,
+                        $messagehtml, $tempfile, $filename);
 
-                if ($result) {
-                    $emailresults[] = "Student email sent to {$user->email}";
-                } else {
-                    $emailfailures[] = "Failed to send student email to {$user->email}";
-                }
-            } catch (\Exception $e) {
-                $emailfailures[] = "Exception sending student email: " . $e->getMessage();
-            }
-        }
-
-        if ($customcert->emailteachers) {
-            try {
-                $teachers = get_enrolled_users($context, 'moodle/course:update');
-
-                $renderable = new \mod_customcert\output\email_certificate(false, $userfullname, $courseshortname,
-                    $coursefullname, $certificatename, $context->instanceid);
-
-                $subject = get_string('emailnonstudentsubject', 'customcert', $info);
-                $message = $textrenderer->render($renderable);
-                $messagehtml = $htmlrenderer->render($renderable);
-
-                foreach ($teachers as $teacher) {
-                    try {
-                        $result = email_to_user($teacher, $userfrom, html_entity_decode($subject, ENT_COMPAT),
-                            $message, $messagehtml, $tempfile, $filename);
-
-                        if ($result) {
-                            $emailresults[] = "Teacher email sent to {$teacher->email}";
-                        } else {
-                            $emailfailures[] = "Failed to send teacher email to {$teacher->email}";
-                        }
-                    } catch (\Exception $e) {
-                        $emailfailures[] = "Exception sending teacher email to {$teacher->email}: " . $e->getMessage();
+                    if ($result) {
+                        $emailresults[] = "Student email sent to {$user->email}";
+                    } else {
+                        $emailfailures[] = "Failed to send student email to {$user->email}";
                     }
+                } catch (\Exception $e) {
+                    $emailfailures[] = "Exception sending student email: " . $e->getMessage();
                 }
-            } catch (\Exception $e) {
-                $emailfailures[] = "Exception getting teachers or sending teacher emails: " . $e->getMessage();
             }
-        }
 
-        if (!empty($customcert->emailothers)) {
-            try {
-                $others = explode(',', $customcert->emailothers);
-                $renderable = new \mod_customcert\output\email_certificate(false, $userfullname,
-    $courseshortname, $coursefullname, $certificatename, $context->instanceid);
+            if ($customcert->emailteachers) {
+                try {
+                    $teachers = get_enrolled_users($context, 'moodle/course:update');
+
+                    $renderable = new \mod_customcert\output\email_certificate(false, $userfullname, $courseshortname,
+                    $coursefullname, $certificatename, $context->instanceid);
 
                     $subject = get_string('emailnonstudentsubject', 'customcert', $info);
                     $message = $textrenderer->render($renderable);
                     $messagehtml = $htmlrenderer->render($renderable);
 
+                    foreach ($teachers as $teacher) {
+                        try {
+                            $result = email_to_user($teacher, $userfrom, html_entity_decode($subject, ENT_COMPAT),
+                                $message, $messagehtml, $tempfile, $filename);
+
+                            if ($result) {
+                                    $emailresults[] = "Teacher email sent to {$teacher->email}";
+                            } else {
+                                $emailfailures[] = "Failed to send teacher email to {$teacher->email}";
+                            }
+                        } catch (\Exception $e) {
+                            $emailfailures[] = "Exception sending teacher email to {$teacher->email}: " . $e->getMessage();
+                        }
+                    }
+                } catch (\Exception $e) {
+                    $emailfailures[] = "Exception getting teachers or sending teacher emails: " . $e->getMessage();
+                }
+            }
+
+            if (!empty($customcert->emailothers)) {
+                try {
+                    $others = explode(',', $customcert->emailothers);
+                    $renderable = new \mod_customcert\output\email_certificate(false, $userfullname,
+                    $courseshortname, $coursefullname, $certificatename, $context->instanceid);
+
+                        $subject = get_string('emailnonstudentsubject', 'customcert', $info);
+                        $message = $textrenderer->render($renderable);
+                        $messagehtml = $htmlrenderer->render($renderable);
+
                     foreach ($others as $email) {
                         $email = trim($email);
                         if (validate_email($email)) {
                             try {
-                            $emailuser = new \stdClass();
-                            $emailuser->id = -1;
-                            $emailuser->email = $email;
+                                $emailuser = new \stdClass();
+                                $emailuser->id = -1;
+                                $emailuser->email = $email;
 
-                            $result = email_to_user($emailuser, $userfrom, html_entity_decode($subject, ENT_COMPAT), $message,
+                                $result = email_to_user($emailuser, $userfrom, html_entity_decode($subject, ENT_COMPAT), $message,
                                 $messagehtml, $tempfile, $filename);
 
-                            if ($result) {
-                                $emailresults[] = "Other email sent to {$email}";
-                            } else {
-                                $emailfailures[] = "Failed to send other email to {$email}";
+                                if ($result) {
+                                    $emailresults[] = "Other email sent to {$email}";
+                                } else {
+                                    $emailfailures[] = "Failed to send other email to {$email}";
+                                }
+                            } catch (\Exception $e) {
+                                $emailfailures[] = "Exception sending other email to {$email}: " . $e->getMessage();
                             }
-                        } catch (\Exception $e) {
-                            $emailfailures[] = "Exception sending other email to {$email}: " . $e->getMessage();
+                        } else {
+                            $emailfailures[] = "Invalid email address in others list: {$email}";
                         }
-                    } else {
-                        $emailfailures[] = "Invalid email address in others list: {$email}";
                     }
+                } catch (\Exception $e) {
+                    $emailfailures[] = "Exception processing other email addresses: " . $e->getMessage();
                 }
-            } catch (\Exception $e) {
-                $emailfailures[] = "Exception processing other email addresses: " . $e->getMessage();
             }
-        }
 
-        // Log results
-        if (!empty($emailresults)) {
-            mtrace("Email successes for issue ID $issueid: " . implode(', ', $emailresults));
-        }
+            // Log results
+            if (!empty($emailresults)) {
+                mtrace("Email successes for issue ID $issueid: " . implode(', ', $emailresults));
+            }
 
-        if (!empty($emailfailures)) {
-            mtrace("Email failures for issue ID $issueid: " . implode(', ', $emailfailures));
-            debugging("Certificate email failures for issue ID $issueid: " . implode('; ', $emailfailures), DEBUG_DEVELOPER);
-        }
+            if (!empty($emailfailures)) {
+                mtrace("Email failures for issue ID $issueid: " . implode(', ', $emailfailures));
+                debugging("Certificate email failures for issue ID $issueid: " . implode('; ', $emailfailures), DEBUG_DEVELOPER);
+            }
 
-        if (empty($emailresults)) {
-            throw new \moodle_exception("No emails sent successfully for issue ID $issueid; retrying later.");
-        }
-        $transaction->allow_commit();
-        // Clean up temporary file
-        if (file_exists($tempfile)) {
-            unlink($tempfile);
-        }
+            if (empty($emailresults)) {
+                throw new \moodle_exception("No emails sent successfully for issue ID $issueid; retrying later.");
+            }
+            $transaction->allow_commit();
+            // Clean up temporary file
+            if (file_exists($tempfile)) {
+                unlink($tempfile);
+            }
         } catch (\Exception $e) {
             $emailfailures[] = "Email sending failed: " . $e->getMessage();
             $transaction->rollback($e);

--- a/classes/task/email_certificate_task.php
+++ b/classes/task/email_certificate_task.php
@@ -136,7 +136,6 @@ class email_certificate_task extends \core\task\adhoc_task {
         } catch (\Exception $e) {
             // Log PDF generation failure and allow retry by throwing exception.
             mtrace('Certificate PDF generation failed for issue ID ' . $issueid . ': ' . $e->getMessage());
-            debugging('Certificate PDF generation failed: ' . $e->getMessage(), DEBUG_DEVELOPER);
             throw new \moodle_exception('PDF generation failed: ' . $e->getMessage());
         }
 
@@ -151,7 +150,6 @@ class email_certificate_task extends \core\task\adhoc_task {
         $tempfile = $tempdir . '/' . md5(microtime() . $user->id . random_int(1000, 9999)) . '.pdf';
         if (file_put_contents($tempfile, $filecontents) === false) {
             mtrace('Certificate PDF could not be written to temp file for issue ID ' . $issueid);
-            debugging('Certificate PDF write failed for issue ID ' . $issueid, DEBUG_DEVELOPER);
             throw new \moodle_exception('Failed to write PDF to temporary file');
         }
 
@@ -270,7 +268,6 @@ class email_certificate_task extends \core\task\adhoc_task {
 
             if (!empty($emailfailures)) {
                 mtrace("Email failures for issue ID $issueid: " . implode(', ', $emailfailures));
-                debugging("Certificate email failures for issue ID $issueid: " . implode('; ', $emailfailures), DEBUG_DEVELOPER);
             }
 
             if (empty($emailresults)) {


### PR DESCRIPTION
@fulldecent, please review.

### Fix: Prevent duplicate emails on certificate task failure

This PR addresses a critical issue in `mod_customcert\task\email_certificate_task` where duplicate emails were being sent repeatedly if the task failed before setting the `emailed` flag in the `customcert_issues` table. This resulted in a "doom loop" of email retries in production.

#### Key changes:

-   **Added pre-check**: Skip the task if the certificate has already been emailed (`emailed = 1`).

-   **Moved `emailed` flag update before sending emails**: This ensures the task is not retried if email sending fails, avoiding duplicate sends.

-   **Wrapped email logic in a DB transaction**: Ensures atomicity; rolls back if no email is sent successfully.

-   **Improved logging and exception handling**: Captures and logs both successes and failures per recipient type (students, teachers, others).

-   **Added safety around PDF generation and temp file creation**.

* * * * *

✅ **Tested on staging**:\
I enabled "Email students" for an ACLS cognitive certificate, created a new account, and successfully received the email (see attached screenshot). This was the only test conducted.

<img width="978" alt="Screenshot 2025-06-23 at 7 33 36 PM" src="https://github.com/user-attachments/assets/9a1d0fd1-e346-4cbf-bc9b-2768837fda86" />
