### PR TITLE
Fix certificate issuance when emailing teachers or others

### DIFF
--- a/backup/moodle2/backup_customcert_stepslib.php
+++ b/backup/moodle2/backup_customcert_stepslib.php
@@ -41,8 +41,8 @@ class backup_customcert_activity_structure_step extends backup_activity_structur
         $customcert = new backup_nested_element('customcert', ['id'], [
             'templateid', 'name', 'intro', 'introformat', 'requiredtime', 'verifyany',
             'deliveryoption', 'usecustomfilename', 'customfilenamepattern', 'emailstudents',
-            'emailteachers', 'emailothers', 'protection', 'language', 'timecreated',
-            'timemodified']);
+            'emailteachers', 'emailothers', 'issueautomatically', 'protection', 'language',
+            'timecreated', 'timemodified']);
 
         // The template.
         $template = new backup_nested_element('template', ['id'], [

--- a/classes/task/issue_certificates_task.php
+++ b/classes/task/issue_certificates_task.php
@@ -55,6 +55,7 @@ class issue_certificates_task extends \core\task\scheduled_task {
         $emailotherslengthsql = $DB->sql_length('c.emailothers');
 
         $sql = "SELECT DISTINCT c.id, c.templateid, c.course, c.requiredtime, c.emailstudents, c.emailteachers, $emailothersselect,
+                       c.issueautomatically,
                        ct.id AS templateid, ct.name AS templatename, ct.contextid, co.id AS courseid,
                        co.fullname AS coursefullname, co.shortname AS courseshortname
                   FROM {customcert} c
@@ -146,6 +147,10 @@ class issue_certificates_task extends \core\task\scheduled_task {
 
             $completion = new \completion_info(get_course((int)$customcert->courseid));
 
+            // Auto-issue only for "Email students", or when this certificate's own "Issue
+            // certificates automatically" setting is enabled (#672, #904).
+            $autoissue = !empty($customcert->emailstudents) || !empty($customcert->issueautomatically);
+
             foreach ($filteredusers as $filtereduser) {
                 // Do not issue certs to suspended users.
                 if ($filtereduser->suspended) {
@@ -200,11 +205,7 @@ class issue_certificates_task extends \core\task\scheduled_task {
                 if (!empty($issue)) {
                     $issueid = (int)$issue->id;
                     $emailed = (int)$issue->emailed;
-                } else if (!empty($customcert->emailstudents)) {
-                    // Only proactively issue a certificate on the student's behalf when emailstudents
-                    // is enabled. Otherwise (e.g. only emailteachers/emailothers is set), we must not
-                    // manufacture a certificate for a student who hasn't triggered issuance themselves
-                    // (e.g. by viewing it) -- we can only notify about certificates that already exist.
+                } else if ($autoissue) {
                     $issueid = \mod_customcert\certificate::issue_certificate($customcert->id, $filtereduser->id);
                     $emailed = 0;
                 }

--- a/db/access.php
+++ b/db/access.php
@@ -134,6 +134,16 @@ $capabilities = [
         'clonepermissionsfrom' => 'moodle/course:manageactivities',
     ],
 
+    'mod/customcert:manageautomaticissuance' => [
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'moodle/course:manageactivities',
+    ],
+
     'mod/customcert:manageverifyany' => [
         'captype' => 'write',
         'contextlevel' => CONTEXT_COURSE,

--- a/db/install.xml
+++ b/db/install.xml
@@ -20,6 +20,7 @@
         <FIELD NAME="emailstudents" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="emailteachers" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="emailothers" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="issueautomatically" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="protection" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="language" TYPE="char" LENGTH="20" NOTNULL="false" SEQUENCE="false" COMMENT="Force certificate to render with specified langauge"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -349,5 +349,16 @@ function xmldb_customcert_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2025041401, 'customcert');
     }
 
+    if ($oldversion < 2025041411) {
+        // Per-certificate opt-in for automatic issuance independent of 'emailstudents' (#672, #904).
+        $table = new xmldb_table('customcert');
+        $field = new xmldb_field('issueautomatically', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '0', 'emailothers');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        upgrade_mod_savepoint(true, 2025041411, 'customcert');
+    }
+
     return true;
 }

--- a/lang/en/customcert.php
+++ b/lang/en/customcert.php
@@ -49,6 +49,7 @@ the certificate.';
 $string['createtemplate'] = 'Create template';
 $string['customcert:addinstance'] = 'Add a new custom certificate instance';
 $string['customcert:manage'] = 'Manage a custom certificate';
+$string['customcert:manageautomaticissuance'] = 'Manage automatic certificate issuance';
 $string['customcert:manageemailothers'] = 'Manage email others setting';
 $string['customcert:manageemailstudents'] = 'Manage email students setting';
 $string['customcert:manageemailteachers'] = 'Manage email teachers setting';
@@ -148,6 +149,8 @@ $string['invalidheight'] = 'The height has to be a valid number greater than 0.'
 $string['invalidmargin'] = 'The margin has to be a valid number greater than 0.';
 $string['invalidposition'] = 'Please select a positive number for position {$a}.';
 $string['invalidwidth'] = 'The width has to be a valid number greater than 0.';
+$string['issueautomatically'] = 'Issue certificates automatically';
+$string['issueautomatically_help'] = 'When enabled, certificates can be automatically issued to eligible users so they can be sent to "Email teachers" or "Email others" recipients even when "Email students" is disabled. When disabled, certificates are only sent to those recipients after the user has obtained their certificate.';
 $string['landscape'] = 'Landscape';
 $string['leftmargin'] = 'Left margin';
 $string['leftmargin_help'] = 'This is the left margin of the certificate PDF in mm.';

--- a/mod_form.php
+++ b/mod_form.php
@@ -97,6 +97,13 @@ class mod_customcert_mod_form extends moodleform_mod {
             $mform->setType('emailothers', PARAM_TEXT);
         }
 
+        if (has_capability('mod/customcert:manageautomaticissuance', $this->get_context())) {
+            $mform->addElement('advcheckbox', 'issueautomatically', get_string('issueautomatically', 'customcert'));
+            $mform->addHelpButton('issueautomatically', 'issueautomatically', 'customcert');
+            $mform->setDefault('issueautomatically', 0);
+            $mform->setType('issueautomatically', PARAM_INT);
+        }
+
         if (has_capability('mod/customcert:manageverifyany', $this->get_context())) {
             $mform->addElement('selectyesno', 'verifyany', get_string('verifycertificateanyone', 'customcert'));
             $mform->addHelpButton('verifyany', 'verifycertificateanyone', 'customcert');
@@ -223,6 +230,7 @@ class mod_customcert_mod_form extends moodleform_mod {
             'emailstudents' => 'mod/customcert:manageemailstudents',
             'emailteachers' => 'mod/customcert:manageemailteachers',
             'emailothers' => 'mod/customcert:manageemailothers',
+            'issueautomatically' => 'mod/customcert:manageautomaticissuance',
             'verifyany' => 'mod/customcert:manageverifyany',
             'requiredtime' => 'mod/customcert:managerequiredtime',
             'protection_print' => 'mod/customcert:manageprotection',

--- a/tests/email_certificate_task_test.php
+++ b/tests/email_certificate_task_test.php
@@ -343,7 +343,7 @@ final class email_certificate_task_test extends advanced_testcase {
 
         // Create a custom certificate. Note emailstudents is not set, so certificates must not be
         // manufactured on the students' behalf -- only students who trigger issuance themselves
-        // (e.g. by viewing the certificate) should be notified about.
+        // (e.g. by obtaining their own certificate) should be notified about.
         $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id,
             'emailteachers' => 1]);
 
@@ -363,7 +363,7 @@ final class email_certificate_task_test extends advanced_testcase {
         $element->name = 'Image';
         $DB->insert_record('customcert_elements', $element);
 
-        // Both students issue their own certificate (e.g. by viewing it) before the task runs.
+        // Both students obtain their own certificate before the task runs.
         \mod_customcert\certificate::issue_certificate($customcert->id, $user1->id);
         \mod_customcert\certificate::issue_certificate($customcert->id, $user2->id);
 
@@ -425,15 +425,195 @@ final class email_certificate_task_test extends advanced_testcase {
         $emails = $sink->get_messages();
         $sink->close();
 
-        // Neither student has viewed the certificate, so no certificates should have been issued.
+        // Neither student has obtained their own certificate, so none should have been issued.
         $this->assertCount(0, $DB->get_records('customcert_issues'));
         $this->assertCount(0, $emails);
     }
 
     /**
+     * Enabling this certificate's "Issue certificates automatically" setting restores the #904
+     * workflow for emailteachers without emailstudents, without making it the default behaviour
+     * (#672 is still protected for certificates that leave the setting off).
+     *
+     * @covers \mod_customcert\task\issue_certificates_task
+     * @covers \mod_customcert\task\email_certificate_task
+     */
+    public function test_email_certificates_teachers_auto_issues_when_setting_enabled(): void {
+        global $DB;
+
+        // Create a course.
+        $course = $this->getDataGenerator()->create_course();
+
+        // Create and enrol two students, plus a teacher; neither student will self-issue.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $teacher = $this->getDataGenerator()->create_user(['firstname' => 'Teacher', 'lastname' => 'One']);
+        $roleids = $DB->get_records_menu('role', null, '', 'shortname, id');
+        $this->getDataGenerator()->enrol_user($user1->id, $course->id);
+        $this->getDataGenerator()->enrol_user($user2->id, $course->id);
+        $this->getDataGenerator()->enrol_user($teacher->id, $course->id, $roleids['editingteacher']);
+
+        // Certificate only notifies teachers, not students, with no restrictions, but opts in to
+        // automatic issuance.
+        $customcert = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'emailteachers' => 1,
+            'issueautomatically' => 1,
+        ]);
+
+        // Put the certificate in a valid state by adding a page + element.
+        $template = new stdClass();
+        $template->id = $customcert->templateid;
+        $template->name = 'A template';
+        $template->contextid = context_course::instance($course->id)->id;
+        $template = new template($template);
+        $pageid = $template->add_page();
+        $DB->insert_record('customcert_elements', (object)['pageid' => $pageid, 'name' => 'E']);
+
+        // Run the task.
+        $sink = $this->redirectEmails();
+        $task = new issue_certificates_task();
+        $task->execute();
+        $emails = $sink->get_messages();
+        $sink->close();
+
+        // With the setting enabled, both students' certificates are issued automatically.
+        $issues = $DB->get_records('customcert_issues');
+        $this->assertCount(2, $issues);
+        $issueuserids = array_column($issues, 'userid');
+        $this->assertContains($user1->id, $issueuserids);
+        $this->assertContains($user2->id, $issueuserids);
+
+        // Both notifications go to the teacher; the students are never emailed directly.
+        $this->assertCount(2, $emails);
+        $tos = array_map(fn($email) => $email->to, $emails);
+        $this->assertSame([$teacher->email, $teacher->email], $tos);
+    }
+
+    /**
+     * Completion conditions still gate issuance even with "Issue certificates automatically"
+     * enabled: eligibility is required in addition to the setting, not bypassed by it.
+     *
+     * @covers \mod_customcert\task\issue_certificates_task
+     * @covers \mod_customcert\task\email_certificate_task
+     */
+    public function test_email_certificates_teachers_respects_completion_with_auto_issue_enabled(): void {
+        global $CFG, $DB;
+
+        $CFG->enablecompletion = true;
+
+        // Create a course with completion enabled.
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+
+        // Create and enrol two students, plus a teacher.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $teacher = $this->getDataGenerator()->create_user(['firstname' => 'Teacher', 'lastname' => 'One']);
+        $roleids = $DB->get_records_menu('role', null, '', 'shortname, id');
+        $this->getDataGenerator()->enrol_user($user1->id, $course->id);
+        $this->getDataGenerator()->enrol_user($user2->id, $course->id);
+        $this->getDataGenerator()->enrol_user($teacher->id, $course->id, $roleids['editingteacher']);
+
+        // Certificate requires viewing the activity to complete it, with automatic issuance enabled.
+        $customcert = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'emailteachers' => 1,
+            'issueautomatically' => 1,
+            'completion' => COMPLETION_TRACKING_AUTOMATIC,
+            'completionview' => 1,
+        ]);
+
+        // Put the certificate in a valid state by adding a page + element.
+        $template = new stdClass();
+        $template->id = $customcert->templateid;
+        $template->name = 'A template';
+        $template->contextid = context_course::instance($course->id)->id;
+        $template = new template($template);
+        $pageid = $template->add_page();
+        $DB->insert_record('customcert_elements', (object)['pageid' => $pageid, 'name' => 'E']);
+
+        // Only user1 has viewed it, meeting the completion condition; user2 has not.
+        $cm = $DB->get_record('course_modules', ['id' => $customcert->cmid]);
+        $completion = new completion_info($course);
+        $completion->set_module_viewed($cm, $user1->id);
+
+        // Run the task.
+        $sink = $this->redirectEmails();
+        $task = new issue_certificates_task();
+        $task->execute();
+        $emails = $sink->get_messages();
+        $sink->close();
+
+        // Only user1's certificate should exist; user2 hasn't met the completion condition, even
+        // though automatic issuance is enabled for this certificate.
+        $issues = $DB->get_records('customcert_issues');
+        $this->assertCount(1, $issues);
+        $issue = reset($issues);
+        $this->assertEquals($user1->id, (int)$issue->userid);
+
+        // Only one email, to the teacher, about user1's certificate.
+        $this->assertCount(1, $emails);
+        $this->assertEquals($teacher->email, $emails[0]->to);
+    }
+
+    /**
+     * "Issue certificates automatically" is stored per certificate, not read from a global
+     * configuration value: two certificates in the same course with different values behave
+     * independently within the same task run.
+     *
+     * @covers \mod_customcert\task\issue_certificates_task
+     * @covers \mod_customcert\task\email_certificate_task
+     */
+    public function test_issueautomatically_is_per_certificate_not_global(): void {
+        global $DB;
+
+        // Create a course.
+        $course = $this->getDataGenerator()->create_course();
+
+        // Create and enrol two students; neither will self-issue.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user1->id, $course->id);
+        $this->getDataGenerator()->enrol_user($user2->id, $course->id);
+
+        // Two unrestricted certificates in the same course, differing only in issueautomatically.
+        $certoff = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'emailteachers' => 1,
+            'issueautomatically' => 0,
+        ]);
+        $certon = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'emailteachers' => 1,
+            'issueautomatically' => 1,
+        ]);
+
+        foreach ([$certoff, $certon] as $customcert) {
+            $template = new stdClass();
+            $template->id = $customcert->templateid;
+            $template->name = 'A template';
+            $template->contextid = context_course::instance($course->id)->id;
+            $template = new template($template);
+            $pageid = $template->add_page();
+            $DB->insert_record('customcert_elements', (object)['pageid' => $pageid, 'name' => 'E']);
+        }
+
+        // Run the task once; it processes every qualifying certificate in the run.
+        $sink = $this->redirectEmails();
+        $task = new issue_certificates_task();
+        $task->execute();
+        $sink->close();
+
+        // The certificate with automatic issuance off must still have no issues (#672); the one
+        // with it on must have issued both students' certificates (#904).
+        $this->assertCount(0, $DB->get_records('customcert_issues', ['customcertid' => $certoff->id]));
+        $this->assertCount(2, $DB->get_records('customcert_issues', ['customcertid' => $certon->id]));
+    }
+
+    /**
      * Tests that the email certificate task only notifies teachers about certificates that were
-     * actually issued (e.g. by a student viewing them), and not about students who were merely
-     * eligible but never triggered issuance themselves.
+     * actually issued (e.g. by a student obtaining their certificate), and not about students who
+     * were merely eligible but never triggered issuance themselves.
      *
      * @covers \mod_customcert\task\issue_certificates_task
      * @covers \mod_customcert\task\email_certificate_task
@@ -468,7 +648,7 @@ final class email_certificate_task_test extends advanced_testcase {
         $pageid = $template->add_page();
         $DB->insert_record('customcert_elements', (object)['pageid' => $pageid, 'name' => 'E']);
 
-        // Only user1 issues their own certificate (e.g. by viewing it); user2 never does.
+        // Only user1 obtains their own certificate; user2 never does.
         \mod_customcert\certificate::issue_certificate($customcert->id, $user1->id);
 
         // Run the task.
@@ -511,7 +691,7 @@ final class email_certificate_task_test extends advanced_testcase {
 
         // Create a custom certificate. Note emailstudents is not set, so certificates must not be
         // manufactured on the students' behalf -- only students who trigger issuance themselves
-        // (e.g. by viewing the certificate) should be notified about.
+        // (e.g. by obtaining their own certificate) should be notified about.
         $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id,
             'emailothers' => 'testcustomcert@example.com, doo@dah']);
 
@@ -531,7 +711,7 @@ final class email_certificate_task_test extends advanced_testcase {
         $element->name = 'Image';
         $DB->insert_record('customcert_elements', $element);
 
-        // Both students issue their own certificate (e.g. by viewing it) before the task runs.
+        // Both students obtain their own certificate before the task runs.
         \mod_customcert\certificate::issue_certificate($customcert->id, $user1->id);
         \mod_customcert\certificate::issue_certificate($customcert->id, $user2->id);
 
@@ -593,9 +773,67 @@ final class email_certificate_task_test extends advanced_testcase {
         $emails = $sink->get_messages();
         $sink->close();
 
-        // Neither student has viewed the certificate, so no certificates should have been issued.
+        // Neither student has obtained their own certificate, so none should have been issued.
         $this->assertCount(0, $DB->get_records('customcert_issues'));
         $this->assertCount(0, $emails);
+    }
+
+    /**
+     * Enabling this certificate's "Issue certificates automatically" setting restores the #904
+     * workflow for emailothers without emailstudents, without making it the default behaviour
+     * (#672 is still protected for certificates that leave the setting off).
+     *
+     * @covers \mod_customcert\task\issue_certificates_task
+     * @covers \mod_customcert\task\email_certificate_task
+     */
+    public function test_email_certificates_others_auto_issues_when_setting_enabled(): void {
+        global $DB;
+
+        // Create a course.
+        $course = $this->getDataGenerator()->create_course();
+
+        // Create and enrol two students; neither will view/issue their own certificate.
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $this->getDataGenerator()->enrol_user($user1->id, $course->id);
+        $this->getDataGenerator()->enrol_user($user2->id, $course->id);
+
+        // Certificate only notifies an external address, not students, with no restrictions, but
+        // opts in to automatic issuance.
+        $customcert = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'emailothers' => 'testcustomcert@example.com',
+            'issueautomatically' => 1,
+        ]);
+
+        // Put the certificate in a valid state by adding a page + element.
+        $template = new stdClass();
+        $template->id = $customcert->templateid;
+        $template->name = 'A template';
+        $template->contextid = context_course::instance($course->id)->id;
+        $template = new template($template);
+        $pageid = $template->add_page();
+        $DB->insert_record('customcert_elements', (object)['pageid' => $pageid, 'name' => 'E']);
+
+        // Run the task.
+        $sink = $this->redirectEmails();
+        $task = new issue_certificates_task();
+        $task->execute();
+        $emails = $sink->get_messages();
+        $sink->close();
+
+        // With the setting enabled, both students' certificates are issued automatically.
+        $issues = $DB->get_records('customcert_issues');
+        $this->assertCount(2, $issues);
+        $issueuserids = array_column($issues, 'userid');
+        $this->assertContains($user1->id, $issueuserids);
+        $this->assertContains($user2->id, $issueuserids);
+
+        // Both notifications go to the configured "others" address; the students are never
+        // emailed directly.
+        $this->assertCount(2, $emails);
+        $tos = array_map(fn($email) => $email->to, $emails);
+        $this->assertSame(['testcustomcert@example.com', 'testcustomcert@example.com'], $tos);
     }
 
     /**
@@ -1002,7 +1240,7 @@ final class email_certificate_task_test extends advanced_testcase {
         $emails = $sink->get_messages();
         $sink->close();
 
-        // Confirm there is an issue as the user has viewed the certificate.
+        // Confirm the certificate was issued once the completion condition was met.
         $issues = $DB->get_records('customcert_issues');
         $this->assertCount(1, $issues);
 

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -47,6 +47,7 @@ class mod_customcert_generator extends testing_module_generator {
             'emailstudents' => 0,
             'emailteachers' => 0,
             'emailothers' => '',
+            'issueautomatically' => 0,
             'protection' => '',
         ];
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -390,4 +390,34 @@ final class lib_test extends advanced_testcase {
         $this->expectException('required_capability_exception');
         mod_customcert_output_fragment_editelement($args);
     }
+
+    /**
+     * The upgrade step that introduced issueautomatically must default existing certificates to
+     * 0 (disabled), preserving the #672 behaviour for sites that have not opted in.
+     *
+     * @covers ::xmldb_customcert_upgrade
+     */
+    public function test_upgrade_defaults_issueautomatically_to_disabled(): void {
+        global $DB, $CFG;
+
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', ['course' => $course->id]);
+
+        $dbman = $DB->get_manager();
+        $table = new \xmldb_table('customcert');
+        $field = new \xmldb_field('issueautomatically');
+        $dbman->drop_field($table, $field);
+
+        // Upgrade_mod_savepoint() refuses to "advance" to a version that isn't strictly greater
+        // than what's on record, so roll the stored plugin version back to simulate a site that
+        // is genuinely upgrading from before this field existed.
+        set_config('version', 2025041410, 'mod_customcert');
+
+        require_once($CFG->libdir . '/upgradelib.php');
+        require_once($CFG->dirroot . '/mod/customcert/db/upgrade.php');
+        xmldb_customcert_upgrade(2025041410);
+
+        $this->assertTrue($dbman->field_exists($table, new \xmldb_field('issueautomatically')));
+        $this->assertEquals(0, (int)$DB->get_field('customcert', 'issueautomatically', ['id' => $customcert->id]));
+    }
 }

--- a/tests/mod_form_automatic_issuance_test.php
+++ b/tests/mod_form_automatic_issuance_test.php
@@ -1,0 +1,253 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests that mod/customcert:manageautomaticissuance gates the "Issue certificates
+ * automatically" setting, independently of the manageemail* capabilities.
+ *
+ * @package    mod_customcert
+ * @copyright  2026 Mark Nelson <mdjnelson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+declare(strict_types=1);
+
+namespace mod_customcert;
+
+use advanced_testcase;
+use context_course;
+use MoodleQuickForm;
+use ReflectionClass;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/customcert/mod_form.php');
+require_once($CFG->dirroot . '/mod/customcert/lib.php');
+require_once($CFG->libdir . '/formslib.php');
+
+/**
+ * Tests that mod/customcert:manageautomaticissuance gates the "Issue certificates
+ * automatically" setting, independently of the manageemail* capabilities.
+ *
+ * @package    mod_customcert
+ * @copyright  2026 Mark Nelson <mdjnelson@gmail.com>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+final class mod_form_automatic_issuance_test extends advanced_testcase {
+    /**
+     * Build a mod_customcert_mod_form with the given context, skipping the constructor (which
+     * would otherwise eagerly build the full form and require a real course module context).
+     *
+     * @param \context $context
+     * @param object $current Value for $this->current, e.g. (object)['add' => 'customcert'] for
+     *   a new instance.
+     * @return \mod_customcert_mod_form
+     */
+    private function make_form(\context $context, object $current): \mod_customcert_mod_form {
+        $refclass = new ReflectionClass(\mod_customcert_mod_form::class);
+        $form = $refclass->newInstanceWithoutConstructor();
+
+        $formprop = $refclass->getProperty('_form');
+        $formprop->setAccessible(true);
+        $formprop->setValue($form, new MoodleQuickForm('mod_form_automatic_issuance_test', 'post', '#'));
+
+        $contextprop = $refclass->getProperty('context');
+        $contextprop->setAccessible(true);
+        $contextprop->setValue($form, $context);
+
+        $currentprop = $refclass->getProperty('current');
+        $currentprop->setAccessible(true);
+        $currentprop->setValue($form, $current);
+
+        return $form;
+    }
+
+    /**
+     * Create a course, a user with a fresh role in it, and return [user, context, roleid].
+     *
+     * @return array{0: \stdClass, 1: \context_course, 2: int}
+     */
+    private function create_user_with_role(): array {
+        $course = $this->getDataGenerator()->create_course();
+        $context = context_course::instance($course->id);
+        $user = $this->getDataGenerator()->create_user();
+
+        $roleid = create_role('Certificate manager', 'certmanager', 'Test role');
+        role_assign($roleid, $user->id, $context->id);
+
+        return [$user, $context, $roleid];
+    }
+
+    /**
+     * The capability-to-field mapping used to fill in defaults on new instances (when the
+     * current user lacks the mapped capability) must include issueautomatically. This mapping
+     * plays no part in preserving the value on update -- that happens because the checkbox is
+     * simply never registered on the form for a capability-less user, so it is absent from
+     * submitted data and update_instance() never writes over the stored value (see the
+     * test_update_instance_* tests below).
+     *
+     * @covers \mod_customcert_mod_form::get_options_elements_with_required_caps
+     */
+    public function test_options_elements_with_required_caps_includes_issueautomatically(): void {
+        $this->resetAfterTest();
+
+        $refclass = new ReflectionClass(\mod_customcert_mod_form::class);
+        $form = $refclass->newInstanceWithoutConstructor();
+        $method = $refclass->getMethod('get_options_elements_with_required_caps');
+        $method->setAccessible(true);
+
+        $map = $method->invoke($form);
+
+        $this->assertArrayHasKey('issueautomatically', $map);
+        $this->assertSame('mod/customcert:manageautomaticissuance', $map['issueautomatically']);
+    }
+
+    /**
+     * A user without manageautomaticissuance never has the field in their submitted data (the
+     * mform never registers it for them), so on a new instance it falls back to the default.
+     * This is the same mechanism that already protects emailstudents/emailteachers/emailothers.
+     *
+     * @covers \mod_customcert_mod_form::data_postprocessing
+     */
+    public function test_new_instance_defaults_issueautomatically_without_capability(): void {
+        $this->resetAfterTest();
+
+        [$user, $context, $roleid] = $this->create_user_with_role();
+        assign_capability('mod/customcert:manageautomaticissuance', CAP_PROHIBIT, $roleid, $context->id, true);
+        accesslib_clear_all_caches_for_unit_testing();
+        $this->setUser($user);
+
+        $form = $this->make_form($context, (object)['add' => 'customcert']);
+
+        // No issueautomatically key: the field was never registered for this user, so it can
+        // never appear in real submitted data, regardless of what a crafted POST contains.
+        $data = (object)['add' => 1];
+        $form->data_postprocessing($data);
+
+        $this->assertTrue(empty($data->issueautomatically));
+    }
+
+    /**
+     * A user with manageautomaticissuance submits the field normally, and their value passes
+     * through data_postprocessing() untouched.
+     *
+     * @covers \mod_customcert_mod_form::data_postprocessing
+     */
+    public function test_new_instance_preserves_submitted_issueautomatically_with_capability(): void {
+        $this->resetAfterTest();
+
+        [$user, $context, $roleid] = $this->create_user_with_role();
+        assign_capability('mod/customcert:manageautomaticissuance', CAP_ALLOW, $roleid, $context->id, true);
+        accesslib_clear_all_caches_for_unit_testing();
+        $this->setUser($user);
+
+        $form = $this->make_form($context, (object)['add' => 'customcert']);
+
+        $data = (object)['add' => 1, 'issueautomatically' => 1];
+        $form->data_postprocessing($data);
+
+        $this->assertEquals(1, $data->issueautomatically);
+    }
+
+    /**
+     * Editing an existing certificate as a user without manageautomaticissuance must not reset
+     * issueautomatically: since the field was never in their submitted data, update_instance()
+     * only ever writes the columns actually present on $data, leaving the stored value alone.
+     *
+     * @covers ::customcert_update_instance
+     */
+    public function test_update_instance_preserves_issueautomatically_when_absent_from_submission(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'issueautomatically' => 1,
+        ]);
+
+        // Simulate the submission of a user without manageautomaticissuance: the checkbox was
+        // never added to their form, so issueautomatically is simply absent, even though they
+        // are legitimately editing some other setting (here, the name).
+        $data = (object)[
+            'instance' => $customcert->id,
+            'name' => 'Renamed by a user without manageautomaticissuance',
+        ];
+
+        customcert_update_instance($data, null);
+
+        $this->assertEquals(1, (int)$DB->get_field('customcert', 'issueautomatically', ['id' => $customcert->id]));
+        $this->assertEquals(
+            'Renamed by a user without manageautomaticissuance',
+            $DB->get_field('customcert', 'name', ['id' => $customcert->id])
+        );
+    }
+
+    /**
+     * A user with manageautomaticissuance submits a real change to the setting, and
+     * update_instance() applies it.
+     *
+     * @covers ::customcert_update_instance
+     */
+    public function test_update_instance_applies_issueautomatically_when_submitted(): void {
+        global $DB;
+
+        $this->resetAfterTest();
+
+        $course = $this->getDataGenerator()->create_course();
+        $customcert = $this->getDataGenerator()->create_module('customcert', [
+            'course' => $course->id,
+            'issueautomatically' => 1,
+        ]);
+
+        $data = (object)['instance' => $customcert->id, 'issueautomatically' => 0];
+        customcert_update_instance($data, null);
+
+        $this->assertEquals(0, (int)$DB->get_field('customcert', 'issueautomatically', ['id' => $customcert->id]));
+    }
+
+    /**
+     * mod/customcert:manageautomaticissuance is independent of mod/customcert:manageemailothers:
+     * a user who can manage "Email others" but not automatic issuance keeps their emailothers
+     * submission untouched while issueautomatically still falls back to the default.
+     *
+     * @covers \mod_customcert_mod_form::data_postprocessing
+     */
+    public function test_manageautomaticissuance_independent_of_manageemailothers(): void {
+        $this->resetAfterTest();
+
+        [$user, $context, $roleid] = $this->create_user_with_role();
+        assign_capability('mod/customcert:manageemailothers', CAP_ALLOW, $roleid, $context->id, true);
+        assign_capability('mod/customcert:manageautomaticissuance', CAP_PROHIBIT, $roleid, $context->id, true);
+        accesslib_clear_all_caches_for_unit_testing();
+        $this->setUser($user);
+
+        $this->assertTrue(has_capability('mod/customcert:manageemailothers', $context));
+        $this->assertFalse(has_capability('mod/customcert:manageautomaticissuance', $context));
+
+        $form = $this->make_form($context, (object)['add' => 'customcert']);
+
+        // The emailothers field was submitted (this user has that capability); issueautomatically was not,
+        // since they lack that one -- both fields are otherwise handled by the same loop.
+        $data = (object)['add' => 1, 'emailothers' => 'teacher@example.com'];
+        $form->data_postprocessing($data);
+
+        $this->assertEquals('teacher@example.com', $data->emailothers);
+        $this->assertTrue(empty($data->issueautomatically));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die('Direct access to this script is forbidden.');
 
-$plugin->version   = 2025041410; // The current module version (Date: YYYYMMDDXX).
+$plugin->version   = 2025041411; // The current module version (Date: YYYYMMDDXX).
 $plugin->requires  = 2025041400; // Requires this Moodle version (5.0).
 $plugin->cron      = 0; // Period for cron to check this module (secs).
 $plugin->component = 'mod_customcert';


### PR DESCRIPTION
Fixes #904 while preserving the behaviour introduced for #672.

Adds a per-certificate option to automatically issue certificates when `"Email teachers"` or `"Email others"` is enabled without `"Email students"`.

The new setting defaults to disabled, so certificates are not automatically created unless explicitly enabled. A new `mod/customcert:manageautomaticissuance` capability controls who can manage this setting.

Includes regression coverage for both #672 and #904.